### PR TITLE
Without vcl

### DIFF
--- a/inc/dg/backend/config.h
+++ b/inc/dg/backend/config.h
@@ -10,14 +10,14 @@
 #elif defined( _MSC_VER)
 # define RESTRICT __restrict
 #else
-#pragma message( "Don't know restrict keyword for this compiler!")
+#pragma message( "WARNING: Don't know restrict keyword for this compiler!")
 # define RESTRICT
 #endif
 
 //%%%%%%%%%%%%%%%%check for fast FMAs %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 #include <cmath>
 #ifndef FP_FAST_FMA
-#pragma message( "Fast std::fma(a,b,c) not activated! Using a*b+c instead!")
+#pragma message( "NOTE: Fast std::fma(a,b,c) not activated! Using a*b+c instead!")
 #define DG_FMA(a,b,c) (a*b+c)
 #else
 #define DG_FMA(a,b,c) (std::fma(a,b,c))
@@ -29,7 +29,7 @@
 #if defined(__INTEL_COMPILER)
 
 #if __INTEL_COMPILER < 1500
-#pragma message( "icc version >= 15.0 recommended to activate OpenMP 4 support")
+#pragma message( "NOTE: icc version >= 15.0 recommended (to activate OpenMP 4 support)")
 #define SIMD
 #else//>1500
 #define SIMD simd
@@ -48,7 +48,7 @@
 #endif //GCC_VERSION
 
 #elif defined(_MSC_VER)
-#pragma message( "No OpenMP 4 support on your compiler")
+#pragma message( "WARNING: No OpenMP 4 support on your compiler")
 #define SIMD
 #endif //compilers
 #endif //THRUST_DEVICE_SYSTEM

--- a/inc/dg/backend/exblas/ExSUM.FPE.hpp
+++ b/inc/dg/backend/exblas/ExSUM.FPE.hpp
@@ -116,11 +116,11 @@ inline static T KnuthTwoSum(T a, T b, T & s)
 template<typename T>
 inline static T TwoProductFMA(T a, T b, T &d) {
     T p = a * b;
-#ifdef WITHOUT_VCL
+#ifdef _WITHOUT_VCL
     d = a*b-p;
 #else
     d = vcl::mul_sub_x(a, b, p); //extra precision even if FMA is not available
-#endif//WITHOUT_VCL
+#endif//_WITHOUT_VCL
     return p;
 }
 
@@ -148,7 +148,7 @@ inline static T TwoProductFMA(T a, T b, T &d) {
 template<typename T>
 inline static T FMA2Sum(T a, T b, T & s)
 {
-#ifndef WITHOUT_VCL
+#ifndef _WITHOUT_VCL
     T r = a + b;
     T z = vcl::mul_sub(1., r, a);
     s = vcl::mul_add(1., a - vcl::mul_sub(1., r, z), b - z);
@@ -158,7 +158,7 @@ inline static T FMA2Sum(T a, T b, T & s)
     T z = r - a;
     s = (a - (r - z)) + (b - z);
     return r;
-#endif//WITHOUT_VCL
+#endif//_WITHOUT_VCL
 }
 
 template<typename T, int N, typename TRAITS> UNROLL_ATTRIBUTE
@@ -411,7 +411,7 @@ void FPExpansionVect<T,N,TRAITS>::FlushVector(T x) const
 {
     // TODO: update status, handle Inf/Overflow/NaN cases
     // TODO: make it work for other values of 4
-#ifndef WITHOUT_VCL
+#ifndef _WITHOUT_VCL
     double v[8];
     x.store(v);
 
@@ -423,7 +423,7 @@ void FPExpansionVect<T,N,TRAITS>::FlushVector(T x) const
     }
 #else
     exblas::cpu::Accumulate(superacc, x);
-#endif //WITHOUT_VCL
+#endif //_WITHOUT_VCL
 }
 
 template<typename T, int N, typename TRAITS>

--- a/inc/dg/backend/exblas/accumulate.h
+++ b/inc/dg/backend/exblas/accumulate.h
@@ -167,7 +167,7 @@ double Round( int64_t * accumulator) {
     if (i == 0) {
         return negative ? -hi : hi;  // Correct rounding achieved
     }
-    hiword -= llrint(rounded);
+    hiword -= std::llrint(rounded);
     double mid = ldexp((double) hiword, (i - F_WORDS) * DIGITS);
 
     // Compute sticky

--- a/inc/dg/backend/exblas/config.h
+++ b/inc/dg/backend/exblas/config.h
@@ -28,9 +28,10 @@
 #include "vcl/vectorclass.h" //vcl by Agner Fog, may also include immintrin.h e.g.
 #include "vcl/instrset_detect.cpp"
 #if INSTRSET <5
-#error "Instruction set SSE4.1 is required! -msse4.1"
+#define _WITHOUT_VCL
+#pragma message("WARNING: Instruction set below SSE4.1! Deactivating vectorization!")
 #elif INSTRSET <7
-#pragma message( "It is recommended to activate AVX instruction set (-mavx) or higher")
+#pragma message( "NOTE: If available, it is recommended to activate AVX instruction set (-mavx) or higher")
 #endif//INSTRSET
 
 #endif//_WITHOUT_VCL

--- a/inc/dg/backend/exblas/exdot_serial.h
+++ b/inc/dg/backend/exblas/exdot_serial.h
@@ -31,10 +31,8 @@ namespace cpu{
 
 template<typename CACHE>
 void ExDOTFPE_cpu(int N, const double *a, const double *b, int64_t* acc) {
-    assert( vcl::instrset_detect() >= 7);
-    //assert( vcl::hasFMA3() );
     CACHE cache(acc);
-
+#ifndef WITHOUT_VCL
     int r = (( int64_t(N) ) & ~7ul);
     for(int i = 0; i < r; i+=8) {
 #ifndef _MSC_VER
@@ -54,14 +52,21 @@ void ExDOTFPE_cpu(int N, const double *a, const double *b, int64_t* acc) {
         cache.Accumulate(x);
         cache.Accumulate(r1);
     }
+#else// WITHOUT_VCL
+    for(int i = 0; i < N; i++) {
+        double r1;
+        double x = TwoProductFMA(a[i],b[i],r1);
+        cache.Accumulate(x);
+        cache.Accumulate(r1);
+    }
+#endif// WITHOUT_VCL
     cache.Flush();
 }
 
 template<typename CACHE>
 void ExDOTFPE_cpu(int N, const double *a, const double *b, const double *c, int64_t* acc) {
-    assert( vcl::instrset_detect() >= 7);
-    //assert( vcl::hasFMA3() );
     CACHE cache(acc);
+#ifndef WITHOUT_VCL
     int r = (( int64_t(N))  & ~7ul);
     for(int i = 0; i < r; i+=8) {
 #ifndef _MSC_VER
@@ -91,6 +96,13 @@ void ExDOTFPE_cpu(int N, const double *a, const double *b, const double *c, int6
         //cache.Accumulate(x2);
         //cache.Accumulate(r2);
     }
+#else// WITHOUT_VCL
+    for(int i = 0; i < N; i++) {
+        double x1 = a[i]*b[i];
+        double x2 = x1*c[i];
+        cache.Accumulate(x2);
+    }
+#endif// WITHOUT_VCL
     cache.Flush();
 }
 }//namespace cpu
@@ -107,11 +119,15 @@ void ExDOTFPE_cpu(int N, const double *a, const double *b, const double *c, int6
  * @sa \c exblas::cpu::Round  to convert the superaccumulator into a double precision number
 */
 void exdot_cpu(unsigned size, const double* x1_ptr, const double* x2_ptr, int64_t* h_superacc){
+#ifndef WITHOUT_VCL
     assert( vcl::instrset_detect() >= 7);
     //assert( vcl::hasFMA3() );
     for( int i=0; i<exblas::BIN_COUNT; i++)
         h_superacc[i] = 0;
     cpu::ExDOTFPE_cpu<cpu::FPExpansionVect<vcl::Vec8d, 8, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, h_superacc);
+#else
+    cpu::ExDOTFPE_cpu<cpu::FPExpansionVect<double, 8, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, h_superacc);
+#endif//WITHOUT_VCL
 }
 
 /*!@brief gpu version of exact triple dot product
@@ -126,11 +142,15 @@ void exdot_cpu(unsigned size, const double* x1_ptr, const double* x2_ptr, int64_
  * @sa \c exblas::cpu::Round  to convert the superaccumulator into a double precision number
  */
 void exdot_cpu(unsigned size, const double *x1_ptr, const double* x2_ptr, const double * x3_ptr, int64_t* h_superacc) {
+#ifndef WITHOUT_VCL
     assert( vcl::instrset_detect() >= 7);
     //assert( vcl::hasFMA3() );
     for( int i=0; i<exblas::BIN_COUNT; i++)
         h_superacc[i] = 0;
     cpu::ExDOTFPE_cpu<cpu::FPExpansionVect<vcl::Vec8d, 8, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, x3_ptr, h_superacc);
+#else
+    cpu::ExDOTFPE_cpu<cpu::FPExpansionVect<double, 8, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, x3_ptr, h_superacc);
+#endif//WITHOUT_VCL
 }
 
 

--- a/inc/dg/backend/exblas/exdot_serial.h
+++ b/inc/dg/backend/exblas/exdot_serial.h
@@ -32,7 +32,7 @@ namespace cpu{
 template<typename CACHE>
 void ExDOTFPE_cpu(int N, const double *a, const double *b, int64_t* acc) {
     CACHE cache(acc);
-#ifndef WITHOUT_VCL
+#ifndef _WITHOUT_VCL
     int r = (( int64_t(N) ) & ~7ul);
     for(int i = 0; i < r; i+=8) {
 #ifndef _MSC_VER
@@ -52,21 +52,21 @@ void ExDOTFPE_cpu(int N, const double *a, const double *b, int64_t* acc) {
         cache.Accumulate(x);
         cache.Accumulate(r1);
     }
-#else// WITHOUT_VCL
+#else// _WITHOUT_VCL
     for(int i = 0; i < N; i++) {
         double r1;
         double x = TwoProductFMA(a[i],b[i],r1);
         cache.Accumulate(x);
         cache.Accumulate(r1);
     }
-#endif// WITHOUT_VCL
+#endif// _WITHOUT_VCL
     cache.Flush();
 }
 
 template<typename CACHE>
 void ExDOTFPE_cpu(int N, const double *a, const double *b, const double *c, int64_t* acc) {
     CACHE cache(acc);
-#ifndef WITHOUT_VCL
+#ifndef _WITHOUT_VCL
     int r = (( int64_t(N))  & ~7ul);
     for(int i = 0; i < r; i+=8) {
 #ifndef _MSC_VER
@@ -96,13 +96,13 @@ void ExDOTFPE_cpu(int N, const double *a, const double *b, const double *c, int6
         //cache.Accumulate(x2);
         //cache.Accumulate(r2);
     }
-#else// WITHOUT_VCL
+#else// _WITHOUT_VCL
     for(int i = 0; i < N; i++) {
         double x1 = a[i]*b[i];
         double x2 = x1*c[i];
         cache.Accumulate(x2);
     }
-#endif// WITHOUT_VCL
+#endif// _WITHOUT_VCL
     cache.Flush();
 }
 }//namespace cpu
@@ -119,7 +119,7 @@ void ExDOTFPE_cpu(int N, const double *a, const double *b, const double *c, int6
  * @sa \c exblas::cpu::Round  to convert the superaccumulator into a double precision number
 */
 void exdot_cpu(unsigned size, const double* x1_ptr, const double* x2_ptr, int64_t* h_superacc){
-#ifndef WITHOUT_VCL
+#ifndef _WITHOUT_VCL
     assert( vcl::instrset_detect() >= 7);
     //assert( vcl::hasFMA3() );
     for( int i=0; i<exblas::BIN_COUNT; i++)
@@ -127,7 +127,7 @@ void exdot_cpu(unsigned size, const double* x1_ptr, const double* x2_ptr, int64_
     cpu::ExDOTFPE_cpu<cpu::FPExpansionVect<vcl::Vec8d, 8, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, h_superacc);
 #else
     cpu::ExDOTFPE_cpu<cpu::FPExpansionVect<double, 8, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, h_superacc);
-#endif//WITHOUT_VCL
+#endif//_WITHOUT_VCL
 }
 
 /*!@brief gpu version of exact triple dot product
@@ -142,7 +142,7 @@ void exdot_cpu(unsigned size, const double* x1_ptr, const double* x2_ptr, int64_
  * @sa \c exblas::cpu::Round  to convert the superaccumulator into a double precision number
  */
 void exdot_cpu(unsigned size, const double *x1_ptr, const double* x2_ptr, const double * x3_ptr, int64_t* h_superacc) {
-#ifndef WITHOUT_VCL
+#ifndef _WITHOUT_VCL
     assert( vcl::instrset_detect() >= 7);
     //assert( vcl::hasFMA3() );
     for( int i=0; i<exblas::BIN_COUNT; i++)
@@ -150,7 +150,7 @@ void exdot_cpu(unsigned size, const double *x1_ptr, const double* x2_ptr, const 
     cpu::ExDOTFPE_cpu<cpu::FPExpansionVect<vcl::Vec8d, 8, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, x3_ptr, h_superacc);
 #else
     cpu::ExDOTFPE_cpu<cpu::FPExpansionVect<double, 8, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, x3_ptr, h_superacc);
-#endif//WITHOUT_VCL
+#endif//_WITHOUT_VCL
 }
 
 

--- a/inc/dg/backend/exblas/mylibm.hpp
+++ b/inc/dg/backend/exblas/mylibm.hpp
@@ -20,6 +20,8 @@
 #include <stdint.h> //definition of int64_t
 #include <cmath>
 #include <cassert>
+#ifndef WITHOUT_VCL
+
 #define MAX_VECTOR_SIZE 512 //configuration of vcl
 #define VCL_NAMESPACE vcl
 #include "vcl/vectorclass.h" //vcl by Agner Fog, may also include immintrin.h e.g.
@@ -28,7 +30,9 @@
 #error "Instruction set SSE4.1 is required! -msse4.1"
 #elif INSTRSET <7
 #pragma message( "It is recommended to activate AVX instruction set (-mavx) or higher")
-#endif
+#endif//INSTRSET
+
+#endif//WITHOUT_VCL
 
 #if defined __INTEL_COMPILER
 #define UNROLL_ATTRIBUTE
@@ -65,25 +69,16 @@ namespace cpu{
 #endif
 
 inline int64_t myllrint(double x) {
+#ifndef WITHOUT_VCL
     return _mm_cvtsd_si64(_mm_set_sd(x));
+#else
+    return llrint(x);
+#endif
 }
-
-template<typename T>
-inline T mylrint(double x) { assert(false); }
-
-template<>
-inline int64_t mylrint<int64_t>(double x) {
-    return _mm_cvtsd_si64(_mm_set_sd(x));
-}
-
-template<>
-inline int32_t mylrint<int32_t>(double x) {
-    return _mm_cvtsd_si32(_mm_set_sd(x));
-}
-
 
 inline double myrint(double x)
 {
+#ifndef WITHOUT_VCL
 #if defined __GNUG__ || _MSC_VER
     // Workaround gcc bug 51033
     union {
@@ -102,6 +97,9 @@ inline double myrint(double x)
     asm(ASM_BEGIN "roundsd %0, %1, 0" ASM_END : "=x" (r) : "x" (x));
     return r;
 #endif
+#else
+    return std::rint(x);
+#endif//WITHOUT_VCL
 }
 
 //inline double uint64_as_double(uint64_t i)
@@ -229,13 +227,34 @@ inline static int64_t xadd(int64_t & memref, int64_t x, unsigned char & of)
 //    vcl::Vec4d m = vcl::max(m1, m2);
 //    return m[0];    // Why is it so hard to convert from vector xmm register to scalar xmm register?
 //}
-
+//
+//inline static void horizontal_twosum(vcl::Vec8d & r, vcl::Vec8d & s)
+//{
+//    //r = KnuthTwoSum(r, s, s);
+//    transpose1(r, s);
+//    r = KnuthTwoSum(r, s, s);
+//    transpose2(r, s);
+//    r = KnuthTwoSum(r, s, s);
+//}
+//
+//static inline bool sign_horizontal_or (vcl::Vec8db const & a) {
+//    //effectively tests if any element in a is non zero
+//    return vcl::horizontal_or( a);
+//    //return !_mm512_testz_pd(a,a);
+//}
+#ifndef WITHOUT_VCL
 inline static bool horizontal_or(vcl::Vec8d const & a) {
     //return _mm512_movemask_pd(a) != 0;
     vcl::Vec8db p = a != 0;
     return vcl::horizontal_or( p);
     //return !_mm512_testz_pd(p, p);
 }
+#else
+inline static bool horizontal_or( const double & a){
+    return a!= 0;
+}
+#endif//WITHOUT_VCL
+
 
 }//namespace cpu
 }//namespace exblas

--- a/inc/dg/backend/exblas/mylibm.hpp
+++ b/inc/dg/backend/exblas/mylibm.hpp
@@ -17,59 +17,13 @@
 #ifndef MYLIBM_HPP_INCLUDED
 #define MYLIBM_HPP_INCLUDED
 
-#include <stdint.h> //definition of int64_t
-#include <cmath>
-#include <cassert>
-#ifndef WITHOUT_VCL
-
-#define MAX_VECTOR_SIZE 512 //configuration of vcl
-#define VCL_NAMESPACE vcl
-#include "vcl/vectorclass.h" //vcl by Agner Fog, may also include immintrin.h e.g.
-#include "vcl/instrset_detect.cpp"
-#if INSTRSET <5
-#error "Instruction set SSE4.1 is required! -msse4.1"
-#elif INSTRSET <7
-#pragma message( "It is recommended to activate AVX instruction set (-mavx) or higher")
-#endif//INSTRSET
-
-#endif//WITHOUT_VCL
-
-#if defined __INTEL_COMPILER
-#define UNROLL_ATTRIBUTE
-#define INLINE_ATTRIBUTE
-#elif defined __GNUC__
-#define UNROLL_ATTRIBUTE __attribute__((optimize("unroll-loops")))
-#define INLINE_ATTRIBUTE __attribute__((always_inline))
-#else
-#define UNROLL_ATTRIBUTE
-#define INLINE_ATTRIBUTE
-#endif
-
-#ifdef ATT_SYNTAX
-#define ASM_BEGIN ".intel_syntax;"
-#define ASM_END ";.att_syntax"
-#else
-#define ASM_BEGIN
-#define ASM_END
-#endif
-
-// Debug mode
-#define paranoid_assert(x) assert(x)
+#include "config.h"
 
 namespace exblas{
 namespace cpu{
 
-// Making C code less readable in an attempt to make assembly more readable
-#if not defined _MSC_VER //there is no builtin_expect on msvc:
-#define likely(x)       __builtin_expect(!!(x), 1)
-#define unlikely(x)     __builtin_expect(!!(x), 0)
-#else
-#define likely(x) (x)
-#define unlikely(x) (x)
-#endif
-
 inline int64_t myllrint(double x) {
-#ifndef WITHOUT_VCL
+#ifndef _WITHOUT_VCL
     return _mm_cvtsd_si64(_mm_set_sd(x));
 #else
     return llrint(x);
@@ -78,7 +32,7 @@ inline int64_t myllrint(double x) {
 
 inline double myrint(double x)
 {
-#ifndef WITHOUT_VCL
+#ifndef _WITHOUT_VCL
 #if defined __GNUG__ || _MSC_VER
     // Workaround gcc bug 51033
     union {
@@ -99,7 +53,7 @@ inline double myrint(double x)
 #endif
 #else
     return std::rint(x);
-#endif//WITHOUT_VCL
+#endif//_WITHOUT_VCL
 }
 
 //inline double uint64_as_double(uint64_t i)
@@ -242,7 +196,7 @@ inline static int64_t xadd(int64_t & memref, int64_t x, unsigned char & of)
 //    return vcl::horizontal_or( a);
 //    //return !_mm512_testz_pd(a,a);
 //}
-#ifndef WITHOUT_VCL
+#ifndef _WITHOUT_VCL
 inline static bool horizontal_or(vcl::Vec8d const & a) {
     //return _mm512_movemask_pd(a) != 0;
     vcl::Vec8db p = a != 0;
@@ -253,7 +207,7 @@ inline static bool horizontal_or(vcl::Vec8d const & a) {
 inline static bool horizontal_or( const double & a){
     return a!= 0;
 }
-#endif//WITHOUT_VCL
+#endif//_WITHOUT_VCL
 
 
 }//namespace cpu

--- a/inc/dg/backend/exblas/mylibm.hpp
+++ b/inc/dg/backend/exblas/mylibm.hpp
@@ -26,7 +26,7 @@ inline int64_t myllrint(double x) {
 #ifndef _WITHOUT_VCL
     return _mm_cvtsd_si64(_mm_set_sd(x));
 #else
-    return llrint(x);
+    return std::llrint(x);
 #endif
 }
 


### PR DESCRIPTION
Introduce WITHOUT_VCL macro that is automatically set if compiled with nvcc or without vectorization instruction flags (Now the minimum compiler versions are given by the C++11 standard requirement)
The idea now is that the user should not know about this flag, it is set automatically when needed