### PR TITLE
Debug

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -96,7 +96,7 @@ ln -s path/to/vcl
 ----
 
 ____
-If you do not like this, you can also create your own config file as
+If you do not like this, you can also set the include paths in your own config file as
 described link:config/README.md[here].
 ____
 
@@ -278,30 +278,43 @@ ____
 
 === Running a FELTOR simulation
 
-Now, we want to compile and run a simulation program. First, we have to
+Now, we want to compile and run a simulation program. To this end, we have to
 download and install some additional libraries for I/O-operations.
 
+First, we need to install jsoncpp (distributed under the MIT License).
+The easiest way to do this on Linux is to install `libjsoncpp-dev` through the package managment system. However, if you have
+a GPU or if you do not have sudo privileges you have to install the library manually. That means you have to clone https://www.github.com/open-source-parsers/jsoncpp[JsonCpp] and follow the instructions in the README. After this, link the
+include path
+[source,sh]
+----
+cd ~/include
+ln -s /usr/include/jsoncpp/json # if installed as a system library
+# or
+ln -s path/to/jsoncpp/include/json # if installed manually
+----
+or append the respective path as well as the path to the object library to the `INCLUDE` and `JSONLIB` variables as
+described under link:config/README.md[config].
+
 For data output we use the
-http://www.unidata.ucar.edu/software/netcdf/[NetCDF] library under an
-MIT - like license. The underlying https://www.hdfgroup.org/HDF5/[HDF5]
-library also uses a very permissive license. Note that for the mpi
+http://www.unidata.ucar.edu/software/netcdf/[NetCDF-C] library under an
+MIT - like license (we use the netcdf-4 file format).
+The underlying https://www.hdfgroup.org/HDF5/[HDF5]
+library also uses a very permissive license.
+Both can be installed easily on Linux through the `libnetcdf-dev` package.
+For a manual build follow the build instructions in the https://www.unidata.ucar.edu/software/netcdf/docs/getting_and_building_netcdf.html[netcdf-documentation].
+Note that for the mpi
 versions of applications you need to build hdf5 and netcdf with the
---enable-parallel flag. Do NOT use the pnetcdf library, which uses the
-classic netcdf file format. Our JSON input files are parsed by
-https://www.github.com/open-source-parsers/jsoncpp[JsonCpp] distributed
-under the MIT license.
-____
+`--enable-parallel` flag. Do NOT use the pnetcdf library, which uses the
+classic netcdf file format.
+
 Some desktop applications in FELTOR use the
 https://github.com/mwiesenberger/draw[draw library] (developed by us
 also under MIT), which depends on OpenGL (s.a.
 http://en.wikibooks.org/wiki/OpenGL_Programming[installation guide]) and
-http://www.glfw.org[glfw], an OpenGL development library under a
-BSD-like license.
-____
+http://www.glfw.org[glfw3], an OpenGL development library under a
+BSD-like license. Again, link `path/to/draw` in the `include` folder.
 
-As in Step 3 you need to create links to the jsoncpp library include
-path (and optionally the draw library) in your include folder or provide
-the paths in your config file. We are ready to compile now
+We are now ready to compile and run a simulation program
 
 [source,sh]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -283,7 +283,7 @@ download and install some additional libraries for I/O-operations.
 
 First, we need to install jsoncpp (distributed under the MIT License).
 The easiest way to do this on Linux is to install `libjsoncpp-dev` through the package managment system. However, if you have
-a GPU or if you do not have sudo privileges you have to install the library manually. That means you have to clone https://www.github.com/open-source-parsers/jsoncpp[JsonCpp] and follow the instructions in the README. After this, link the
+a GPU or if you do not have sudo privileges you have to install the library manually. That means you have to clone https://www.github.com/open-source-parsers/jsoncpp[JsonCpp] and follow the build instructions in the README. After this, link the
 include path
 [source,sh]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -196,7 +196,7 @@ To compile and run this code for a GPU use
 
 [source,sh]
 ----
-nvcc -x cu -Ipath/to/feltor/inc -Ipath/to/thrust/thrust -Ipath/to/cusplibrary/cusp test.cpp -o test
+nvcc -x cu -std=c++11 -Ipath/to/feltor/inc -Ipath/to/thrust/thrust -Ipath/to/cusplibrary/cusp test.cpp -o test
 ./test
 ----
 
@@ -205,7 +205,7 @@ functions you can also use
 
 [source,sh]
 ----
-g++ -fopenmp -mavx -mfma -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_OMP -Ipath/to/feltor/inc -Ipath/to/thrust/thrust -Ipath/to/cusplibrary/cusp test.cpp -o test
+g++ -std=c++11 -fopenmp -mavx -mfma -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_OMP -Ipath/to/feltor/inc -Ipath/to/thrust/thrust -Ipath/to/cusplibrary/cusp test.cpp -o test
 export OMP_NUM_THREADS=4
 ./test
 ----
@@ -248,7 +248,7 @@ Compile e.g. for a hybrid MPI {plus} OpenMP hardware platform with
 
 [source,sh]
 ----
-mpic++ -mavx -mfma -fopenmp -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_OMP -Ipath/to/feltor/inc -Ipath/to/thrust/thrust -Ipath/to/cusplibrary/cusp test_mpi.cpp -o test_mpi
+mpic++ -std=c++11 -mavx -mfma -fopenmp -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_OMP -Ipath/to/feltor/inc -Ipath/to/thrust/thrust -Ipath/to/cusplibrary/cusp test_mpi.cpp -o test_mpi
 export OMP_NUM_THREADS=2
 mpirun -n 4 ./test_mpi
 ----

--- a/diag/feltordiag.cu
+++ b/diag/feltordiag.cu
@@ -3,6 +3,7 @@
 #include <iomanip>
 #include <vector>
 #include <string>
+#include "json/json.h"
 
 #include "dg/algorithm.h"
 #include "file/nc_utilities.h"

--- a/diag/filamentdiag.cu
+++ b/diag/filamentdiag.cu
@@ -3,6 +3,7 @@
 #include <iomanip>
 #include <vector>
 #include <string>
+#include "json/json.h"
 
 #include "dg/algorithm.h"
 #include "geometries/geometries.h"

--- a/diag/ncdiag.cpp
+++ b/diag/ncdiag.cpp
@@ -3,6 +3,7 @@
 #include <iomanip>
 #include <vector>
 #include <string>
+#include "json/json.h"
 
 #include "dg/algorithm.h"
 #include "geometries/geometries.h"

--- a/inc/dg/backend/average_cpu.h
+++ b/inc/dg/backend/average_cpu.h
@@ -29,8 +29,10 @@ void extend_column( SerialTag, unsigned nx, unsigned ny, const value_type* in, v
             out[i*nx+j] = in[i];
 }
 
-void average( SerialTag, unsigned nx, unsigned ny, const double* in0, const double* in1, double* out)
+template<class value_type>
+void average( SerialTag, unsigned nx, unsigned ny, const value_type* in0, const value_type* in1, value_type* out)
 {
+    static_assert( std::is_same<value_type, double>::value, "Value type must be double!");
     static thrust::host_vector<int64_t> h_accumulator;
     h_accumulator.resize( ny*exblas::BIN_COUNT);
     for( unsigned i=0; i<ny; i++)
@@ -41,8 +43,10 @@ void average( SerialTag, unsigned nx, unsigned ny, const double* in0, const doub
 
 #ifdef MPI_VERSION
 //local data plus communication
-void average_mpi( SerialTag, unsigned nx, unsigned ny, const double* in0, const double* in1, double* out, MPI_Comm comm, MPI_Comm comm_mod, MPI_Comm comm_mod_reduce )
+template<class value_type>
+void average_mpi( SerialTag, unsigned nx, unsigned ny, const value_type* in0, const value_type* in1, value_type* out, MPI_Comm comm, MPI_Comm comm_mod, MPI_Comm comm_mod_reduce )
 {
+    static_assert( std::is_same<value_type, double>::value, "Value type must be double!");
     static thrust::host_vector<int64_t> h_accumulator;
     static thrust::host_vector<int64_t> h_accumulator2;
     h_accumulator2.resize( ny*exblas::BIN_COUNT);

--- a/inc/dg/backend/average_omp.h
+++ b/inc/dg/backend/average_omp.h
@@ -34,8 +34,10 @@ void extend_column( OmpTag, unsigned nx, unsigned ny, const value_type* RESTRICT
             out[i*nx+j] = in[i];
 }
 
-void average( OmpTag, unsigned nx, unsigned ny, const double* in0, const double* in1, double* out)
+template<class value_type>
+void average( OmpTag, unsigned nx, unsigned ny, const value_type* in0, const value_type* in1, value_type* out)
 {
+    static_assert( std::is_same<value_type, double>::value, "Value type must be double!");
     static thrust::host_vector<int64_t> h_accumulator;
     h_accumulator.resize( ny*exblas::BIN_COUNT);
     for( unsigned i=0; i<ny; i++)
@@ -46,8 +48,10 @@ void average( OmpTag, unsigned nx, unsigned ny, const double* in0, const double*
 
 #ifdef MPI_VERSION
 //local data plus communication
-void average_mpi( OmpTag, unsigned nx, unsigned ny, const double* in0, const double* in1, double* out, MPI_Comm comm, MPI_Comm comm_mod, MPI_Comm comm_mod_reduce )
+template<class value_type>
+void average_mpi( OmpTag, unsigned nx, unsigned ny, const value_type* in0, const value_type* in1, value_type* out, MPI_Comm comm, MPI_Comm comm_mod, MPI_Comm comm_mod_reduce )
 {
+    static_assert( std::is_same<value_type, double>::value, "Value type must be double!");
     static thrust::host_vector<int64_t> h_accumulator;
     static thrust::host_vector<int64_t> h_accumulator2;
     h_accumulator2.resize( ny*exblas::BIN_COUNT);

--- a/inc/dg/backend/exblas/accumulate.cuh
+++ b/inc/dg/backend/exblas/accumulate.cuh
@@ -30,7 +30,7 @@ namespace gpu
 ////////////////////////////////////////////////////////////////////////////////
 ///@cond
 __device__
-inline void AccumulateWord( int64_t *accumulator, int i, int64_t x, int stride = 1) {
+static inline void AccumulateWord( int64_t *accumulator, int i, int64_t x, int stride = 1) {
     // With atomic superacc updates
     // accumulation and carry propagation can happen in any order,
     // as long as addition is atomic
@@ -79,7 +79,7 @@ inline void AccumulateWord( int64_t *accumulator, int i, int64_t x, int stride =
 * @param stride stride in which accumulator is to be accessed
 */
 __device__
-inline void Accumulate( int64_t* accumulator, double x, int stride = 1) { //transposed accumulation
+static inline void Accumulate( int64_t* accumulator, double x, int stride = 1) { //transposed accumulation
     if (x == 0)
         return;
 
@@ -117,7 +117,7 @@ inline void Accumulate( int64_t* accumulator, double x, int stride = 1) { //tran
 * @return  carry in bit (sign)
 */
 __device__
-int Normalize( int64_t *accumulator, int& imin, int& imax, int stride = 1) {
+static int Normalize( int64_t *accumulator, int& imin, int& imax, int stride = 1) {
     int64_t carry_in = accumulator[(imin)*stride] >> DIGITS;
     accumulator[(imin)*stride] -= carry_in << DIGITS;
     int i;
@@ -148,7 +148,7 @@ int Normalize( int64_t *accumulator, int& imin, int& imax, int stride = 1) {
 * @return the double precision number nearest to the superaccumulator
 */
 __device__
-double Round( int64_t * accumulator) {
+static inline double Round( int64_t * accumulator) {
     int imin = IMIN;
     int imax = IMAX;
     int negative = Normalize(accumulator, imin, imax);

--- a/inc/dg/backend/exblas/accumulate.h
+++ b/inc/dg/backend/exblas/accumulate.h
@@ -27,7 +27,7 @@ namespace cpu {
 // Main computation pass: compute partial superaccs
 ////////////////////////////////////////////////////////////////////////////////
 ///@cond
-inline void AccumulateWord( int64_t *accumulator, int i, int64_t x) {
+static inline void AccumulateWord( int64_t *accumulator, int i, int64_t x) {
     // With atomic accumulator updates
     // accumulation and carry propagation can happen in any order,
     // as long as addition is atomic
@@ -74,7 +74,7 @@ inline void AccumulateWord( int64_t *accumulator, int i, int64_t x) {
 * @param accumulator a pointer to at least \c BIN_COUNT 64 bit integers on the CPU (representing the superaccumulator)
 * @param x the double to add to the superaccumulator
 */
-inline void Accumulate( int64_t* accumulator, double x) {
+static inline void Accumulate( int64_t* accumulator, double x) {
     if (x == 0)
         return;
 
@@ -111,7 +111,7 @@ inline void Accumulate( int64_t* accumulator, double x) {
 *
 * @return  carry in bit (sign)
 */
-bool Normalize( int64_t *accumulator, int& imin, int& imax) {
+static inline bool Normalize( int64_t *accumulator, int& imin, int& imax) {
     int64_t carry_in = accumulator[imin] >> DIGITS;
     accumulator[imin] -= carry_in << DIGITS;
     int i;
@@ -142,7 +142,7 @@ bool Normalize( int64_t *accumulator, int& imin, int& imax) {
 * @param accumulator a pointer to at least \c BIN_COUNT 64 bit integers on the CPU (representing the superaccumulator)
 * @return the double precision number nearest to the superaccumulator
 */
-double Round( int64_t * accumulator) {
+static inline double Round( int64_t * accumulator) {
     int imin = IMIN;
     int imax = IMAX;
     bool negative = Normalize(accumulator, imin, imax);

--- a/inc/dg/backend/exblas/config.h
+++ b/inc/dg/backend/exblas/config.h
@@ -69,7 +69,6 @@
 namespace exblas
 {
 ////////////// parameters for superaccumulator operations //////////////////////
-///High radix carray-save bits
 static constexpr int KRX            =  8; //!< High-radix carry-save bits
 static constexpr int DIGITS         =  64 - KRX; //!< number of nonoverlapping digits
 static constexpr int F_WORDS        =  20;  //!< number of uper exponent words (64bits)

--- a/inc/dg/backend/exblas/config.h
+++ b/inc/dg/backend/exblas/config.h
@@ -26,7 +26,6 @@
 #define MAX_VECTOR_SIZE 512 //configuration of vcl
 #define VCL_NAMESPACE vcl
 #include "vcl/vectorclass.h" //vcl by Agner Fog, may also include immintrin.h e.g.
-#include "vcl/instrset_detect.cpp"
 #if INSTRSET <5
 #define _WITHOUT_VCL
 #pragma message("WARNING: Instruction set below SSE4.1! Deactivating vectorization!")

--- a/inc/dg/backend/exblas/exdot_omp.h
+++ b/inc/dg/backend/exblas/exdot_omp.h
@@ -222,25 +222,28 @@ void ExDOTFPE(int N, const double *a, const double *b, const double *c, int64_t*
  *
  * Computes the exact sum \f[ \sum_{i=0}^{N-1} x_i y_i \f]
  * @ingroup highlevel
+ * @tparam NBFPE size of the floating point expansion (should be between 3 and 8)
  * @param size size N of the arrays to sum
  * @param x1_ptr first array
  * @param x2_ptr second array
  * @param h_superacc pointer to an array of 64 bit integers (the superaccumulator) in host memory with size at least \c exblas::BIN_COUNT (39) (contents are overwritten)
  * @sa \c exblas::cpu::Round  to convert the superaccumulator into a double precision number
 */
+template<size_t NBFPE=8>
 void exdot_omp(unsigned size, const double* x1_ptr, const double* x2_ptr, int64_t* h_superacc){
 #ifndef _WITHOUT_VCL
     assert( vcl::instrset_detect() >= 7);
     //assert( vcl::hasFMA3() );
-    cpu::ExDOTFPE<cpu::FPExpansionVect<vcl::Vec8d, 8, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, h_superacc);
+    cpu::ExDOTFPE<cpu::FPExpansionVect<vcl::Vec8d, NBFPE, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, h_superacc);
 #else
-    cpu::ExDOTFPE<cpu::FPExpansionVect<double, 8, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, h_superacc);
+    cpu::ExDOTFPE<cpu::FPExpansionVect<double, NBFPE, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, h_superacc);
 #endif//_WITHOUT_VCL
 }
 /*!@brief OpenMP parallel version of exact triple dot product
  *
  * Computes the exact sum \f[ \sum_{i=0}^{N-1} x_i w_i y_i \f]
  * @ingroup highlevel
+ * @tparam NBFPE size of the floating point expansion (should be between 3 and 8)
  * @param size size N of the arrays to sum
  * @param x1_ptr first array
  * @param x2_ptr second array
@@ -248,13 +251,14 @@ void exdot_omp(unsigned size, const double* x1_ptr, const double* x2_ptr, int64_
  * @param h_superacc pointer to an array of 64 bit integegers (the superaccumulator) in host memory with size at least \c exblas::BIN_COUNT (39) (contents are overwritten)
  * @sa \c exblas::cpu::Round  to convert the superaccumulator into a double precision number
  */
+template<size_t NBFPE=8>
 void exdot_omp(unsigned size, const double *x1_ptr, const double* x2_ptr, const double * x3_ptr, int64_t* h_superacc) {
 #ifndef _WITHOUT_VCL
     assert( vcl::instrset_detect() >= 7);
     //assert( vcl::hasFMA3() );
-    cpu::ExDOTFPE<cpu::FPExpansionVect<vcl::Vec8d, 8, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, x3_ptr, h_superacc);
+    cpu::ExDOTFPE<cpu::FPExpansionVect<vcl::Vec8d, NBFPE, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, x3_ptr, h_superacc);
 #else
-    cpu::ExDOTFPE<cpu::FPExpansionVect<double, 8, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, x3_ptr, h_superacc);
+    cpu::ExDOTFPE<cpu::FPExpansionVect<double, NBFPE, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, x3_ptr, h_superacc);
 #endif//_WITHOUT_VCL
 }
 

--- a/inc/dg/backend/exblas/exdot_omp.h
+++ b/inc/dg/backend/exblas/exdot_omp.h
@@ -232,8 +232,6 @@ void ExDOTFPE(int N, const double *a, const double *b, const double *c, int64_t*
 template<size_t NBFPE=8>
 void exdot_omp(unsigned size, const double* x1_ptr, const double* x2_ptr, int64_t* h_superacc){
 #ifndef _WITHOUT_VCL
-    assert( vcl::instrset_detect() >= 7);
-    //assert( vcl::hasFMA3() );
     cpu::ExDOTFPE<cpu::FPExpansionVect<vcl::Vec8d, NBFPE, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, h_superacc);
 #else
     cpu::ExDOTFPE<cpu::FPExpansionVect<double, NBFPE, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, h_superacc);
@@ -254,8 +252,6 @@ void exdot_omp(unsigned size, const double* x1_ptr, const double* x2_ptr, int64_
 template<size_t NBFPE=8>
 void exdot_omp(unsigned size, const double *x1_ptr, const double* x2_ptr, const double * x3_ptr, int64_t* h_superacc) {
 #ifndef _WITHOUT_VCL
-    assert( vcl::instrset_detect() >= 7);
-    //assert( vcl::hasFMA3() );
     cpu::ExDOTFPE<cpu::FPExpansionVect<vcl::Vec8d, NBFPE, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, x3_ptr, h_superacc);
 #else
     cpu::ExDOTFPE<cpu::FPExpansionVect<double, NBFPE, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, x3_ptr, h_superacc);

--- a/inc/dg/backend/exblas/exdot_serial.h
+++ b/inc/dg/backend/exblas/exdot_serial.h
@@ -122,8 +122,6 @@ void ExDOTFPE_cpu(int N, const double *a, const double *b, const double *c, int6
 template<size_t NBFPE=8>
 void exdot_cpu(unsigned size, const double* x1_ptr, const double* x2_ptr, int64_t* h_superacc){
 #ifndef _WITHOUT_VCL
-    assert( vcl::instrset_detect() >= 7);
-    //assert( vcl::hasFMA3() );
     for( int i=0; i<exblas::BIN_COUNT; i++)
         h_superacc[i] = 0;
     cpu::ExDOTFPE_cpu<cpu::FPExpansionVect<vcl::Vec8d, NBFPE, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, h_superacc);
@@ -147,8 +145,6 @@ void exdot_cpu(unsigned size, const double* x1_ptr, const double* x2_ptr, int64_
 template<size_t NBFPE=8>
 void exdot_cpu(unsigned size, const double *x1_ptr, const double* x2_ptr, const double * x3_ptr, int64_t* h_superacc) {
 #ifndef _WITHOUT_VCL
-    assert( vcl::instrset_detect() >= 7);
-    //assert( vcl::hasFMA3() );
     for( int i=0; i<exblas::BIN_COUNT; i++)
         h_superacc[i] = 0;
     cpu::ExDOTFPE_cpu<cpu::FPExpansionVect<vcl::Vec8d, NBFPE, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, x3_ptr, h_superacc);

--- a/inc/dg/backend/exblas/exdot_serial.h
+++ b/inc/dg/backend/exblas/exdot_serial.h
@@ -112,21 +112,23 @@ void ExDOTFPE_cpu(int N, const double *a, const double *b, const double *c, int6
  *
  * Computes the exact sum \f[ \sum_{i=0}^{N-1} x_i y_i \f]
  * @ingroup highlevel
+ * @tparam NBFPE size of the floating point expansion (should be between 3 and 8)
  * @param size size N of the arrays to sum
  * @param x1_ptr first array
  * @param x2_ptr second array
  * @param h_superacc pointer to an array of 64 bit integers (the superaccumulator) in host memory with size at least \c exblas::BIN_COUNT (39) (contents are overwritten)
  * @sa \c exblas::cpu::Round  to convert the superaccumulator into a double precision number
 */
+template<size_t NBFPE=8>
 void exdot_cpu(unsigned size, const double* x1_ptr, const double* x2_ptr, int64_t* h_superacc){
 #ifndef _WITHOUT_VCL
     assert( vcl::instrset_detect() >= 7);
     //assert( vcl::hasFMA3() );
     for( int i=0; i<exblas::BIN_COUNT; i++)
         h_superacc[i] = 0;
-    cpu::ExDOTFPE_cpu<cpu::FPExpansionVect<vcl::Vec8d, 8, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, h_superacc);
+    cpu::ExDOTFPE_cpu<cpu::FPExpansionVect<vcl::Vec8d, NBFPE, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, h_superacc);
 #else
-    cpu::ExDOTFPE_cpu<cpu::FPExpansionVect<double, 8, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, h_superacc);
+    cpu::ExDOTFPE_cpu<cpu::FPExpansionVect<double, NBFPE, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, h_superacc);
 #endif//_WITHOUT_VCL
 }
 
@@ -134,6 +136,7 @@ void exdot_cpu(unsigned size, const double* x1_ptr, const double* x2_ptr, int64_
  *
  * Computes the exact sum \f[ \sum_{i=0}^{N-1} x_i w_i y_i \f]
  * @ingroup highlevel
+ * @tparam NBFPE size of the floating point expansion (should be between 3 and 8)
  * @param size size N of the arrays to sum
  * @param x1_ptr first array
  * @param x2_ptr second array
@@ -141,15 +144,16 @@ void exdot_cpu(unsigned size, const double* x1_ptr, const double* x2_ptr, int64_
  * @param h_superacc pointer to an array of 64 bit integegers (the superaccumulator) in host memory with size at least \c exblas::BIN_COUNT (39) (contents are overwritten)
  * @sa \c exblas::cpu::Round  to convert the superaccumulator into a double precision number
  */
+template<size_t NBFPE=8>
 void exdot_cpu(unsigned size, const double *x1_ptr, const double* x2_ptr, const double * x3_ptr, int64_t* h_superacc) {
 #ifndef _WITHOUT_VCL
     assert( vcl::instrset_detect() >= 7);
     //assert( vcl::hasFMA3() );
     for( int i=0; i<exblas::BIN_COUNT; i++)
         h_superacc[i] = 0;
-    cpu::ExDOTFPE_cpu<cpu::FPExpansionVect<vcl::Vec8d, 8, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, x3_ptr, h_superacc);
+    cpu::ExDOTFPE_cpu<cpu::FPExpansionVect<vcl::Vec8d, NBFPE, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, x3_ptr, h_superacc);
 #else
-    cpu::ExDOTFPE_cpu<cpu::FPExpansionVect<double, 8, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, x3_ptr, h_superacc);
+    cpu::ExDOTFPE_cpu<cpu::FPExpansionVect<double, NBFPE, cpu::FPExpansionTraits<true> > >((int)size,x1_ptr,x2_ptr, x3_ptr, h_superacc);
 #endif//_WITHOUT_VCL
 }
 

--- a/inc/dg/backend/exblas/mpi_accumulate.h
+++ b/inc/dg/backend/exblas/mpi_accumulate.h
@@ -20,7 +20,7 @@ namespace exblas {
  * @param comm_mod_reduce a subgroup of comm, consists of all rank 0 processes in comm_mod
  * @note the creation of new communicators involves communication between all participation processes (comm in this case)
  */
-void mpi_reduce_communicator(MPI_Comm comm, MPI_Comm* comm_mod, MPI_Comm* comm_mod_reduce){
+static void mpi_reduce_communicator(MPI_Comm comm, MPI_Comm* comm_mod, MPI_Comm* comm_mod_reduce){
     int mod = 128;
     int rank, size;
     MPI_Comm_rank( comm, &rank);
@@ -51,7 +51,7 @@ processes.  As usual the resulting superaccumulator is unnormalized.
 @param comm_mod_reduce This is the communicator consisting of all rank 0 processes in comm_mod, may be \c MPI_COMM_NULL
 @sa \c exblas::mpi_reduce_communicator to generate the required communicators
 */
-void reduce_mpi_cpu(  unsigned num_superacc, int64_t* in, int64_t* out, MPI_Comm comm, MPI_Comm comm_mod, MPI_Comm comm_mod_reduce )
+static void reduce_mpi_cpu(  unsigned num_superacc, int64_t* in, int64_t* out, MPI_Comm comm, MPI_Comm comm_mod, MPI_Comm comm_mod_reduce )
 {
     for( unsigned i=0; i<num_superacc; i++)
     {

--- a/inc/dg/backend/exblas/mylibm.cuh
+++ b/inc/dg/backend/exblas/mylibm.cuh
@@ -7,7 +7,7 @@ namespace gpu
 
 //first define device function equivalent to mylibm.hpp
 //returns the original value at address
-__device__ int64_t atomicAdd( int64_t* address, int64_t val)
+__device__ static inline int64_t atomicAdd( int64_t* address, int64_t val)
 {
     unsigned long long int* address_as_ull =
         (unsigned long long int*)address;
@@ -24,7 +24,7 @@ __device__ int64_t atomicAdd( int64_t* address, int64_t val)
     return (int64_t)(old);
 }
 // signedcarry in {-1, 0, 1}
-__device__ int64_t xadd( int64_t &sa, int64_t x, unsigned char &of) {
+__device__ static inline int64_t xadd( int64_t &sa, int64_t x, unsigned char &of) {
     // OF and SF  -> carry=1
     // OF and !SF -> carry=-1
     // !OF        -> carry=0
@@ -43,7 +43,7 @@ __device__ int64_t xadd( int64_t &sa, int64_t x, unsigned char &of) {
 }
 // Assumptions: th>tl>=0, no overlap between th and tl
 __device__
-inline double OddRoundSumNonnegative(double th, double tl) {
+static inline double OddRoundSumNonnegative(double th, double tl) {
     // Adapted from:
     // Sylvie Boldo, and Guillaume Melquiond. "Emulation of a FMA and correctly rounded sums: proved algorithms using rounding to odd." IEEE Transactions on Computers, 57, no. 4 (2008): 462-471.
     union {

--- a/inc/dg/backend/exblas/mylibm.hpp
+++ b/inc/dg/backend/exblas/mylibm.hpp
@@ -22,7 +22,7 @@
 namespace exblas{
 namespace cpu{
 
-inline int64_t myllrint(double x) {
+static inline int64_t myllrint(double x) {
 #ifndef _WITHOUT_VCL
     return _mm_cvtsd_si64(_mm_set_sd(x));
 #else
@@ -30,7 +30,7 @@ inline int64_t myllrint(double x) {
 #endif
 }
 
-inline double myrint(double x)
+static inline double myrint(double x)
 {
 #ifndef _WITHOUT_VCL
 #if defined __GNUG__ || _MSC_VER
@@ -63,7 +63,7 @@ inline double myrint(double x)
 //    return d;
 //}
 
-inline int exponent(double x)
+static inline int exponent(double x)
 {
     // simpler frexp
     union {
@@ -75,7 +75,7 @@ inline int exponent(double x)
     return e;
 }
 
-inline int biased_exponent(double x)
+static inline int biased_exponent(double x)
 {
     union {
         double d;
@@ -86,7 +86,7 @@ inline int biased_exponent(double x)
     return e;
 }
 
-inline double myldexp(double x, int e)
+static inline double myldexp(double x, int e)
 {
     // Scale x by e
     union {
@@ -99,7 +99,7 @@ inline double myldexp(double x, int e)
     return caster.d;
 }
 
-inline double exp2i(int e)
+static inline double exp2i(int e)
 {
     // simpler ldexp
     union {
@@ -112,7 +112,7 @@ inline double exp2i(int e)
 }
 
 // Assumptions: th>tl>=0, no overlap between th and tl
-inline static double OddRoundSumNonnegative(double th, double tl)
+static inline double OddRoundSumNonnegative(double th, double tl)
 {
     // Adapted from:
     // Sylvie Boldo, and Guillaume Melquiond. "Emulation of a FMA and correctly rounded sums: proved algorithms using rounding to odd." IEEE Transactions on Computers, 57, no. 4 (2008): 462-471.

--- a/inc/dg/cg.h
+++ b/inc/dg/cg.h
@@ -463,7 +463,8 @@ struct Invert
      * conjugate gradient method. The initial guess comes from an extrapolation
      * of the last solutions.
      * @copydoc hide_matrix
-     * @tparam Preconditioner A type for which the blas2::symv(Matrix&, Vector1&, Vector2&) function is callable.
+     * @tparam SquareNorm A type for which the blas2::dot( const Matrix&, const Vector&) function is callable. This can e.g. be one of the container types.
+     * @tparam Preconditioner A type for which the <tt> blas2::symv(Matrix&, Vector1&, Vector2&) </tt> function is callable.
      * @param op symmetric Matrix operator class
      * @param phi solution (write only)
      * @param rho right-hand-side (will be multiplied by \c weights)
@@ -475,8 +476,8 @@ struct Invert
      *
      * @return number of iterations used
      */
-    template< class Matrix, class Preconditioner >
-    unsigned operator()( Matrix& op, container& phi, const container& rho, const container& weights, const container& inv_weights, Preconditioner& p)
+    template< class Matrix, class SquareNorm, class Preconditioner >
+    unsigned operator()( Matrix& op, container& phi, const container& rho, const SquareNorm& weights, const SquareNorm& inv_weights, Preconditioner& p)
     {
         assert( phi.size() != 0);
         assert( &rho != &phi);
@@ -489,7 +490,7 @@ struct Invert
         unsigned number;
         if( multiplyWeights_ )
         {
-            dg::blas2::symv( rho, weights, m_ex.tail());
+            dg::blas2::symv( weights, rho, m_ex.tail());
             number = cg( op, phi, m_ex.tail(), p, inv_weights, eps_, nrmb_correction_);
         }
         else

--- a/inc/dg/cg.h
+++ b/inc/dg/cg.h
@@ -27,6 +27,7 @@ namespace dg{
 *
 * @note Conjugate gradients might become unstable for positive semidefinite
 * matrices arising e.g. in the discretization of the periodic laplacian
+* @attention beware the sign: a negative definite matrix does @b not work in Conjugate gradient
 *
 * @snippet cg2d_t.cu doxygen
 */
@@ -61,10 +62,7 @@ class CG
      *
      * The iteration stops if \f$ ||b - Ax|| < \epsilon( ||b|| + C) \f$ where \f$C\f$ is
      * a correction factor to the absolute error
-     * @copydoc hide_matrix
-     * @tparam Preconditioner A class for which the blas2::symv() and
-     blas2::dot( const Matrix&, const Vector&) functions are callable. Currently Preconditioner must be the same as container (diagonal preconditioner) except when container is std::vector<container_type> then Preconditioner can be container_type
-     * @param A A symmetric positive definit matrix
+     * @param A A symmetric, positive definit matrix
      * @param x Contains an initial value on input and the solution on output.
      * @param b The right hand side vector. x and b may be the same vector.
      * @param P The preconditioner to be used
@@ -76,6 +74,9 @@ class CG
      * @note Required memops per iteration (\c P is assumed vector):
              - 11  reads + 3 writes
              - plus the number of memops for \c A;
+     * @copydoc hide_matrix
+     * @tparam Preconditioner A class for which the blas2::symv() and
+     blas2::dot( const Matrix&, const Vector&) functions are callable. Currently Preconditioner must be the same as container (diagonal preconditioner) except when container is std::vector<container_type> then Preconditioner can be container_type
      */
     template< class Matrix, class Preconditioner >
     unsigned operator()( Matrix& A, container& x, const container& b, Preconditioner& P , value_type eps = 1e-12, value_type nrmb_correction = 1);
@@ -85,9 +86,6 @@ class CG
      *
      * The iteration stops if \f$ ||Ax||_S < \epsilon( ||b||_S + C) \f$ where \f$C\f$ is
      * a correction factor to the absolute error and \f$ S \f$ defines a square norm
-     * @copydoc hide_matrix
-     * @tparam Preconditioner A type for which the blas2::symv(Matrix&, Vector1&, Vector2&) function is callable.
-     * @tparam SquareNorm A type for which the blas2::dot( const Matrix&, const Vector&) function is callable. This can e.g. be one of the container types.
      * @param A A symmetric positive definit matrix
      * @param x Contains an initial value on input and the solution on output.
      * @param b The right hand side vector. x and b may be the same vector.
@@ -100,6 +98,9 @@ class CG
      * @note Required memops per iteration (\c P and \c S are assumed vectors):
              - 15  reads + 4 writes
              - plus the number of memops for \c A;
+     * @copydoc hide_matrix
+     * @tparam Preconditioner A type for which the blas2::symv(Matrix&, Vector1&, Vector2&) function is callable.
+     * @tparam SquareNorm A type for which the blas2::dot( const Matrix&, const Vector&) function is callable. This can e.g. be one of the container types.
      */
     template< class Matrix, class Preconditioner, class SquareNorm >
     unsigned operator()( Matrix& A, container& x, const container& b, Preconditioner& P, SquareNorm& S, value_type eps = 1e-12, value_type nrmb_correction = 1);
@@ -346,7 +347,6 @@ struct Extrapolation
  *
  * @ingroup invert
  * @snippet elliptic2d_b.cu invert
- * @copydoc hide_container
  * @note A note on weights, inverse weights and preconditioning.
  * A normalized DG-discretized derivative or operator is normally not symmetric.
  * The diagonal coefficient matrix that is used to make the operator
@@ -356,7 +356,9 @@ struct Extrapolation
  * Independent from this, a preconditioner should be used to solve the
  * symmetric matrix equation. The inverse of \f$W\f$ is
  * a good general purpose preconditioner.
+ * @attention beware the sign: a negative definite matrix does @b not work in Conjugate gradient
  * @sa Extrapolation MultigridCG2d
+ * @copydoc hide_container
  */
 template<class container>
 struct Invert

--- a/inc/dg/dg_doc.h
+++ b/inc/dg/dg_doc.h
@@ -184,7 +184,7 @@
  A class for which the \c blas2::symv(Matrix&, Vector1&, Vector2&) function is callable
  with the \c container type as argument. Also, The functions \c %inv_weights() and \c %precond()
  need to be callable and return inverse weights and the preconditioner for the conjugate
- gradient method. The %Operator is assumed to be linear and symmetric!
+ gradient method. \c SymmetricOp is assumed to be linear, symmetric and positive definite!
  @note you can make your own \c SymmetricOp by providing the member function \c void \c symv(const container&, container&);
   and specializing \c MatrixTraits with the \c SelfMadeMatrixTag as the matrix_category
   */

--- a/inc/dg/elliptic.h
+++ b/inc/dg/elliptic.h
@@ -40,16 +40,17 @@ namespace dg
  In a time dependent problem the value of \f$\alpha\f$ determines the
  numerical diffusion, i.e. for too low values numerical oscillations may appear.
  Also note that a forward discretization has more diffusion than a centered discretization.
- The following code snippet demonstrates the use of \c Elliptic in a multigrid algorithm:
- * @snippet elliptic2d_b.cu multigrid
+
+ The following code snippet demonstrates the use of \c Elliptic in an inversion problem
+ * @snippet elliptic2d_b.cu invert
  * @copydoc hide_geometry_matrix_container
- * This class has the SelfMadeMatrixTag so it can be used in blas2::symv functions
+ * This class has the \c SelfMadeMatrixTag so it can be used in blas2::symv functions
  * and thus in a conjugate gradient solver.
  * @note The constructors initialize \f$ \chi=1\f$ so that a negative laplacian operator
  * results
  * @note The inverse of \f$ \chi\f$ makes a good general purpose preconditioner
  * @note the jump term \f$ \alpha J\f$  adds artificial numerical diffusion as discussed above
- * @attention Pay attention to the negative sign
+ * @attention Pay attention to the negative sign which is necessary to make the matrix @b positive @b definite
  *
  */
 template <class Geometry, class Matrix, class container>
@@ -241,10 +242,10 @@ class Elliptic
  *  \f]
  * is discretized, with \f$ b^i\f$ being the contravariant components of \f$\mathbf b\f$ .
  * @copydoc hide_geometry_matrix_container
- * This class has the SelfMadeMatrixTag so it can be used in blas2::symv functions
+ * This class has the \c SelfMadeMatrixTag so it can be used in blas2::symv functions
  * and thus in a conjugate gradient solver.
  * @note The constructors initialize \f$ b^x = b^y = b^z=1\f$
- * @attention Pay attention to the negative sign
+ * @attention Pay attention to the negative sign which is necessary to make the matrix @b positive @b definite
  */
 template< class Geometry, class Matrix, class container>
 struct GeneralElliptic
@@ -424,10 +425,10 @@ struct GeneralElliptic
  *  \f]
  * is discretized, with \f$ b^i\f$ being the contravariant components of \f$\mathbf b\f$ .
  * @copydoc hide_geometry_matrix_container
- * This class has the SelfMadeMatrixTag so it can be used in blas2::symv functions
+ * This class has the \c SelfMadeMatrixTag so it can be used in blas2::symv functions
  * and thus in a conjugate gradient solver.
  * @note The constructors initialize \f$ \chi_x = \chi_y = \chi_z=1\f$
- * @attention Pay attention to the negative sign
+ * @attention Pay attention to the negative sign which is necessary to make the matrix @b positive @b definite
  */
 template<class Geometry, class Matrix, class container>
 struct GeneralEllipticSym
@@ -543,10 +544,10 @@ struct GeneralEllipticSym
  *  \end{align}
  *  \f]
  * @copydoc hide_geometry_matrix_container
- * This class has the SelfMadeMatrixTag so it can be used in blas2::symv functions
+ * This class has the \c SelfMadeMatrixTag so it can be used in blas2::symv functions
  * and thus in a conjugate gradient solver.
  * @note The constructors initialize \f$ \chi = I\f$
- * @attention Pay attention to the negative sign
+ * @attention Pay attention to the negative sign which is necessary to make the matrix @b positive @b definite
  */
 template< class Geometry, class Matrix, class container>
 struct TensorElliptic

--- a/inc/dg/functors.h
+++ b/inc/dg/functors.h
@@ -1153,6 +1153,12 @@ struct SQRT
 
 /**
  * @brief Minmod function
+ \f[ f(x_1, x_2, x_3) = \begin{cases}
+         \min(x_1, x_2, x_3) \text{ for } x_1, x_2, x_3 >0 \\
+         \max(x_1, x_2, x_3) \text{ for } x_1, x_2, x_3 <0 \\
+         0 \text{ else}
+ \end{cases}
+ \f]
  *
  * might be useful for flux limiter schemes
  * @tparam T value-type
@@ -1296,7 +1302,11 @@ struct ABS
 };
 /**
  * @brief returns positive values
- * \f[ f(x) = |x|\f]
+ \f[ f(x) = \begin{cases}
+         x \text{ for } x>0 \\
+         0 \text{ else}
+ \end{cases}
+ \f]
  *
  * @tparam T value type
  */

--- a/inc/dg/geometry/evaluation_t.cu
+++ b/inc/dg/geometry/evaluation_t.cu
@@ -10,11 +10,20 @@
 #include "evaluation.cuh"
 #include "weights.cuh"
 
-
-double function( double x)
+struct exp_function{
+DG_DEVICE
+double operator()( double x)
 {
     return exp(x);
 }
+};
+struct sin_function{
+DG_DEVICE
+double operator()( double x)
+{
+    return sin(x);
+}
+};
 
 double function( double x, double y)
 {
@@ -25,7 +34,6 @@ double function( double x, double y, double z)
         return exp(x)*exp(y)*exp(z);
 }
 
-//typedef std::vector< double>   DVec;
 typedef thrust::device_vector< double>   DVec;
 typedef thrust::host_vector< double>     HVec;
 
@@ -83,11 +91,19 @@ int main()
     std::cout << "Square normalized 3D norm "<<std::setw(6)<<norm3d<<"\t" << res.i - 4746764681002108278<<"\n";
     double solution3d = solution2d*(exp(12.) -exp(10.))/2.;
     std::cout << "Correct square norm is    "<<std::setw(6)<<solution3d<<std::endl;
-    std::cout << "Relative 3d error is      "<<(norm3d-solution3d)/solution3d<<"\n";
+    std::cout << "Relative 3d error is      "<<(norm3d-solution3d)/solution3d<<"\n\n";
 
-    std::cout << "TEST result of a sin function to compare platforms/compilers:\n";
-    res.d = sin( 6.12610567450009658);
-    std::cout << "Result of sin "<<res.d<<"\t"<<res.i<<"\t(GCC: -4628567870976535683)"<<std::endl;
+    std::cout << "TEST result of a sin and exp function to compare compiler specific math libraries:\n";
+    DVec x(1, 6.12610567450009658);
+    dg::blas1::transform( x, x, sin_function() );
+    res.d = x[0];
+    std::cout << "Result of sin:    "<<res.i<<"\n"
+              << "          GCC:    -4628567870976535683 (correct)"<<std::endl;
+    DVec y(1, 5.9126151457310376);
+    dg::blas1::transform( y, y, exp_function() );
+    res.d = y[0];
+    std::cout << "Result of exp:     "<<res.i<<"\n"
+              << "          GCC:     4645210948416067678 (correct)"<<std::endl;
     std::cout << "\nFINISHED! Continue with geometry/derivatives_t.cu !\n\n";
     return 0;
 }

--- a/inc/dg/multistep_t.cu
+++ b/inc/dg/multistep_t.cu
@@ -118,7 +118,7 @@ int main()
     const dg::DVec sol = dg::evaluate( Solution(T,nu), grid);
     const dg::DVec w2d = dg::create::weights( grid);
     const double norm_sol = dg::blas2::dot( w2d, sol);
-    double time = 0., norm_error;
+    double time = 0.;
     dg::DVec error( sol);
 
     dg::AB< 1, dg::DVec > ab1( y0);
@@ -132,41 +132,43 @@ int main()
     ab4.init( full, time, y0, dt);
     ab5.init( full, time, y0, dt);
 
+    exblas::udouble res;
+
     //main time loop
     time = 0., y0 =  init;
     for( unsigned i=0; i<NT; i++)
         ab1.step( full, time, y0);
     dg::blas1::axpby( -1., sol, 1., y0);
-    norm_error = sqrt(dg::blas2::dot( w2d, y0)/norm_sol);
-    std::cout << "Relative error AB 1        is "<< norm_error<<std::endl;
+    res.d = sqrt(dg::blas2::dot( w2d, y0)/norm_sol);
+    std::cout << "Relative error AB 1        is "<< res.d<<"\t"<<res.i<<std::endl;
     //main time loop
     time = 0., y0 =  init;
     for( unsigned i=0; i<NT; i++)
         ab2.step( full, time, y0);
     dg::blas1::axpby( -1., sol, 1., y0);
-    norm_error = sqrt(dg::blas2::dot( w2d, y0)/norm_sol);
-    std::cout << "Relative error AB 2        is "<< norm_error<<std::endl;
+    res.d = sqrt(dg::blas2::dot( w2d, y0)/norm_sol);
+    std::cout << "Relative error AB 2        is "<< res.d<<"\t"<<res.i<<std::endl;
     //main time loop
     time = 0., y0 =  init;
     for( unsigned i=0; i<NT; i++)
         ab3.step( full, time, y0);
     dg::blas1::axpby( -1., sol, 1., y0);
-    norm_error = sqrt(dg::blas2::dot( w2d, y0)/norm_sol);
-    std::cout << "Relative error AB 3        is "<< norm_error<<std::endl;
+    res.d = sqrt(dg::blas2::dot( w2d, y0)/norm_sol);
+    std::cout << "Relative error AB 3        is "<< res.d<<"\t"<<res.i<<std::endl;
     //main time loop
     time = 0., y0 =  init;
     for( unsigned i=0; i<NT; i++)
         ab4.step( full, time, y0);
     dg::blas1::axpby( -1., sol, 1., y0);
-    norm_error = sqrt(dg::blas2::dot( w2d, y0)/norm_sol);
-    std::cout << "Relative error AB 4        is "<< norm_error<<std::endl;
+    res.d = sqrt(dg::blas2::dot( w2d, y0)/norm_sol);
+    std::cout << "Relative error AB 4        is "<< res.d<<"\t"<<res.i<<std::endl;
     //main time loop
     time = 0., y0 =  init;
     for( unsigned i=0; i<NT; i++)
         ab5.step( full, time, y0);
     dg::blas1::axpby( -1., sol, 1., y0);
-    norm_error = sqrt(dg::blas2::dot( w2d, y0)/norm_sol);
-    std::cout << "Relative error AB 5        is "<< norm_error<<std::endl;
+    res.d = sqrt(dg::blas2::dot( w2d, y0)/norm_sol);
+    std::cout << "Relative error AB 5        is "<< res.d<<"\t"<<res.i<<std::endl;
     //![sirk]
     //construct time stepper (eps = 1e-8)
     dg::SIRK< dg::DVec > sirk( y0, y0.size(), eps);
@@ -176,8 +178,8 @@ int main()
         sirk.step( exp, imp, time, y0, time, y0, dt); //inplace step
     //![sirk]
     dg::blas1::axpby( -1., sol, 1., y0);
-    norm_error = sqrt(dg::blas2::dot( w2d, y0)/norm_sol);
-    std::cout << "Relative error SIRK        is "<< norm_error<<std::endl;
+    res.d = sqrt(dg::blas2::dot( w2d, y0)/norm_sol);
+    std::cout << "Relative error SIRK        is "<< res.d<<"\t"<<res.i<<std::endl;
     //![karniadakis]
     //construct time stepper
     dg::Karniadakis< dg::DVec > karniadakis( y0, y0.size(), eps);
@@ -189,8 +191,8 @@ int main()
         karniadakis.step( exp, imp, time, y0); //inplace step
     //![karniadakis]
     dg::blas1::axpby( -1., sol, 1., y0);
-    norm_error = sqrt(dg::blas2::dot( w2d, y0)/norm_sol);
-    std::cout << "Relative error Karniadakis is "<< norm_error<<std::endl;
+    res.d = sqrt(dg::blas2::dot( w2d, y0)/norm_sol);
+    std::cout << "Relative error Karniadakis is "<< res.d<<"\t"<<res.i<<std::endl;
     //main time loop
     std::cout << "\nAdaptive SIRK Timer \n";
     time = 0., y0 =  init;
@@ -201,7 +203,7 @@ int main()
     adapt = T - time;
     sirk.adaptive_step( exp, imp, time, y0, time, y0, adapt, 1e-8, true);
     dg::blas1::axpby( -1., sol, 1., y0);
-    norm_error = sqrt(dg::blas2::dot( w2d, y0)/norm_sol);
-    std::cout << "Relative error adaptive sirk: "<< norm_error<<std::endl;
+    res.d = sqrt(dg::blas2::dot( w2d, y0)/norm_sol);
+    std::cout << "Relative error adaptive sirk: "<< res.d<<"\t"<<res.i<<std::endl;
     return 0;
 }

--- a/inc/geometries/conformalX_elliptic_b.cu
+++ b/inc/geometries/conformalX_elliptic_b.cu
@@ -1,4 +1,5 @@
 #include <iostream>
+#include "json/json.h"
 
 #include "dg/algorithm.h"
 

--- a/inc/geometries/conformal_elliptic_b.cu
+++ b/inc/geometries/conformal_elliptic_b.cu
@@ -1,4 +1,5 @@
 #include <iostream>
+#include "json/json.h"
 
 #include "dg/geometry/grid.h"
 #include "dg/elliptic.h"

--- a/inc/geometries/ds_curv_mpit.cu
+++ b/inc/geometries/ds_curv_mpit.cu
@@ -1,4 +1,5 @@
 #include <iostream>
+#include "json/json.h"
 
 #include "mpi.h"
 

--- a/inc/geometries/ds_curv_t.cu
+++ b/inc/geometries/ds_curv_t.cu
@@ -1,6 +1,7 @@
 #include <iostream>
 
 #include <cusp/print.h>
+#include "json/json.h"
 
 #include "dg/geometry/functions.h"
 #include "dg/backend/timer.cuh"

--- a/inc/geometries/ds_geom_t.cu
+++ b/inc/geometries/ds_geom_t.cu
@@ -7,6 +7,7 @@
 #include <fstream>
 
 #include <cusp/print.h>
+#include "json/json.h"
 
 #include "file/nc_utilities.h"
 #include "draw/host_window.h"

--- a/inc/geometries/ds_guenther_t.cu
+++ b/inc/geometries/ds_guenther_t.cu
@@ -2,6 +2,7 @@
 
 #include <cusp/print.h>
 #include <cusp/csr_matrix.h>
+#include "json/json.h"
 
 #include "dg/algorithm.h"
 #include "ds.h"

--- a/inc/geometries/flux_t.cu
+++ b/inc/geometries/flux_t.cu
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <sstream>
 #include <cmath>
+#include "json/json.h"
 
 #include "dg/algorithm.h"
 

--- a/inc/geometries/geometryX_elliptic_b.cu
+++ b/inc/geometries/geometryX_elliptic_b.cu
@@ -1,6 +1,7 @@
 #include <iostream>
 
 #include "file/nc_utilities.h"
+#include "json/json.h"
 
 #include "dg/algorithm.h"
 

--- a/inc/geometries/geometryX_refined_elliptic_b.cu
+++ b/inc/geometries/geometryX_refined_elliptic_b.cu
@@ -1,4 +1,5 @@
 #include <iostream>
+#include "json/json.h"
 
 #include "file/nc_utilities.h"
 

--- a/inc/geometries/geometry_advection_b.cu
+++ b/inc/geometries/geometry_advection_b.cu
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <iomanip>
 
+#include "json/json.h"
 #include "dg/algorithm.h"
 
 #include "curvilinear.h"

--- a/inc/geometries/geometry_advection_mpib.cu
+++ b/inc/geometries/geometry_advection_mpib.cu
@@ -2,6 +2,7 @@
 #include <iomanip>
 
 #include <mpi.h>
+#include "json/json.h"
 
 #include "dg/arakawa.h"
 #include "dg/poisson.h"

--- a/inc/geometries/geometry_elliptic_b.cu
+++ b/inc/geometries/geometry_elliptic_b.cu
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <memory>
+#include "json/json.h"
 
 #include "file/nc_utilities.h"
 

--- a/inc/geometries/geometry_elliptic_mpib.cu
+++ b/inc/geometries/geometry_elliptic_mpib.cu
@@ -3,6 +3,7 @@
 #include <mpi.h>
 
 #include <netcdf_par.h>
+#include "json/json.h"
 
 #include "file/nc_utilities.h"
 

--- a/inc/geometries/guenther_ds_b.cu
+++ b/inc/geometries/guenther_ds_b.cu
@@ -2,6 +2,7 @@
 
 #include <cusp/print.h>
 #include <cusp/csr_matrix.h>
+#include "json/json.h"
 
 #include "dg/algorithm.h"
 #include "ds.h"

--- a/inc/geometries/guenther_ds_mpib.cu
+++ b/inc/geometries/guenther_ds_mpib.cu
@@ -3,6 +3,7 @@
 #include <mpi.h>
 #include <cusp/print.h>
 #include <cusp/csr_matrix.h>
+#include "json/json.h"
 
 #include "dg/algorithm.h"
 #include "ds.h"

--- a/inc/geometries/guenther_parameters.h
+++ b/inc/geometries/guenther_parameters.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <vector>
-#include "json/json.h"
 /*!@file
  *
  * Geometry parameters for guenther field
@@ -13,6 +12,9 @@ namespace guenther
 {
 /**
  * @brief Constructs and display geometric parameters for the guenther field
+ *
+ * @ingroup geom
+ * @note include \c json/json.h before \c geometries.h in order to activate json functionality
  */
 struct Parameters
 {
@@ -28,6 +30,7 @@ struct Parameters
            psipmaxcut, //!< for cutting
            psipmaxlim; //!< for limiter
     std::vector<double> c;  //!< coefficients for the solovev equilibrium
+#ifdef JSONCPP_VERSION_STRING
     Parameters( const Json::Value& js) {
         I_0  = js["I_0"].asDouble();
         R_0  = js["R_0"].asDouble();
@@ -41,6 +44,7 @@ struct Parameters
         psipmaxcut= js["psip_max_cut"].asDouble();
         psipmaxlim= js["psip_max_lim"].asDouble();
     }
+#endif // JSONCPP_VERSION_STRING
     void display( std::ostream& os = std::cout ) const
     {
         os << "Geometrical parameters are: \n"

--- a/inc/geometries/hector_t.cu
+++ b/inc/geometries/hector_t.cu
@@ -5,6 +5,7 @@
 #include <sstream>
 #include <cmath>
 #include <memory>
+#include "json/json.h"
 
 #include "file/nc_utilities.h"
 

--- a/inc/geometries/ribeiro.h
+++ b/inc/geometries/ribeiro.h
@@ -164,7 +164,7 @@ struct FieldFinv
         fpsi_(psi, x0, y0, mode), fieldRZYTribeiro_(psi, x0, y0), fieldRZYTequalarc_(psi, x0, y0), N_steps(N_steps), mode_(mode) { }
     void operator()(double t, const thrust::host_vector<double>& psi, thrust::host_vector<double>& fpsiM)
     {
-        std::array<double,3> begin( {0,0,0}), end(begin), end_old(begin);
+        std::array<double,3> begin( {0,0,0}), end(begin);
         fpsi_.find_initial( psi[0], begin[0], begin[1]);
         if(mode_==0)dg::stepperRK<17>( fieldRZYTribeiro_,  0., begin, 2*M_PI, end, N_steps);
         if(mode_==1)dg::stepperRK<17>( fieldRZYTequalarc_, 0., begin, 2*M_PI, end, N_steps);

--- a/inc/geometries/ribeiroX.h
+++ b/inc/geometries/ribeiroX.h
@@ -176,7 +176,7 @@ struct XFieldFinv
             { xAtOne_ = fpsi_.find_x(0.1); }
     void operator()(double ttt, const thrust::host_vector<double>& psi, thrust::host_vector<double>& fpsiM)
     {
-        std::array<double,3> begin( {0,0,0}), end(begin), end_old(begin);
+        std::array<double,3> begin( {0,0,0}), end(begin);
         double R_i[2], Z_i[2];
         dg::Timer t;
         t.tic();

--- a/inc/geometries/ribeiroX_t.cu
+++ b/inc/geometries/ribeiroX_t.cu
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <sstream>
 #include <cmath>
+#include "json/json.h"
 
 #include "dg/algorithm.h"
 #include "file/nc_utilities.h"

--- a/inc/geometries/ribeiro_mpit.cu
+++ b/inc/geometries/ribeiro_mpit.cu
@@ -6,6 +6,7 @@
 #include <cmath>
 
 #include <mpi.h>
+#include "json/json.h"
 
 #include "dg/algorithm.h"
 #include "mpi_curvilinear.h"

--- a/inc/geometries/ribeiro_t.cu
+++ b/inc/geometries/ribeiro_t.cu
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <sstream>
 #include <cmath>
+#include "json/json.h"
 
 #include "dg/algorithm.h"
 

--- a/inc/geometries/separatrix_orthogonal_t.cu
+++ b/inc/geometries/separatrix_orthogonal_t.cu
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <sstream>
 #include <cmath>
+#include "json/json.h"
 
 #include "dg/geometry/xspacelib.cuh"
 #include "dg/functors.h"

--- a/inc/geometries/simple_orthogonal_t.cu
+++ b/inc/geometries/simple_orthogonal_t.cu
@@ -5,6 +5,7 @@
 #include <sstream>
 #include <cmath>
 #include <memory>
+#include "json/json.h"
 
 #include "dg/algorithm.h"
 #include "guenther.h"

--- a/inc/geometries/solovev_parameters.h
+++ b/inc/geometries/solovev_parameters.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <string>
 #include <vector>
-#include "json/json.h"
 /*!@file
  *
  * Geometry parameters
@@ -15,6 +14,7 @@ namespace solovev
 /**
  * @brief Constructs and display geometric parameters for the solovev and taylor fields
  * @ingroup geom
+ * @note include \c json/json.h before \c geometries.h in order to activate json functionality
  */
 struct Parameters
 {
@@ -32,6 +32,7 @@ struct Parameters
            qampl; //scales grad-shafranov q factor
     std::vector<double> c;  //!< coefficients for the solovev equilibrium
     std::string equilibrium;
+#ifdef JSONCPP_VERSION_STRING
     Parameters( const Json::Value& js) {
         A  = js.get("A", 0).asDouble();
         c.resize(13);//there are only 12 originially c[12] is to make fieldlines straight
@@ -53,28 +54,6 @@ struct Parameters
         qampl = js.get("qampl", 1.).asDouble();
         equilibrium = js.get( "equilibrium", "solovev").asString();
     }
-    void display( std::ostream& os = std::cout ) const
-    {
-        os << "Geometrical parameters are: \n"
-            <<" A             = "<<A<<"\n";
-        for( unsigned i=0; i<13; i++)
-            os<<" c"<<i+1<<"\t\t = "<<c[i]<<"\n";
-
-        os  <<" R0            = "<<R_0<<"\n"
-            <<" epsilon_a     = "<<a/R_0<<"\n"
-            <<" elongation    = "<<elongation<<"\n"
-            <<" triangularity = "<<triangularity<<"\n"
-            <<" alpha         = "<<alpha<<"\n"
-            <<" rk4 epsilon   = "<<rk4eps<<"\n"
-            <<" psipmin       = "<<psipmin<<"\n"
-            <<" psipmax       = "<<psipmax<<"\n"
-            <<" psipmaxcut    = "<<psipmaxcut<<"\n"
-            <<" psipmaxlim    = "<<psipmaxlim<<"\n"
-            <<" qampl    = "<<qampl<<"\n";
-        os << std::flush;
-
-    }
-
     /**
      * @brief Put values into a json string
      *
@@ -98,6 +77,28 @@ struct Parameters
         js["qampl"] = qampl;
         js[ "equilibrium"] = equilibrium;
         return js;
+    }
+#endif // JSONCPP_VERSION_STRING
+    void display( std::ostream& os = std::cout ) const
+    {
+        os << "Geometrical parameters are: \n"
+            <<" A             = "<<A<<"\n";
+        for( unsigned i=0; i<13; i++)
+            os<<" c"<<i+1<<"\t\t = "<<c[i]<<"\n";
+
+        os  <<" R0            = "<<R_0<<"\n"
+            <<" epsilon_a     = "<<a/R_0<<"\n"
+            <<" elongation    = "<<elongation<<"\n"
+            <<" triangularity = "<<triangularity<<"\n"
+            <<" alpha         = "<<alpha<<"\n"
+            <<" rk4 epsilon   = "<<rk4eps<<"\n"
+            <<" psipmin       = "<<psipmin<<"\n"
+            <<" psipmax       = "<<psipmax<<"\n"
+            <<" psipmaxcut    = "<<psipmaxcut<<"\n"
+            <<" psipmaxlim    = "<<psipmaxlim<<"\n"
+            <<" qampl    = "<<qampl<<"\n";
+        os << std::flush;
+
     }
 };
 } //namespace solovev

--- a/inc/geometries/utilitiesX.h
+++ b/inc/geometries/utilitiesX.h
@@ -456,7 +456,7 @@ struct SeparatriX
             thrust::host_vector<double>& z ) const
     {
         ///////////////////////////find y coordinate line//////////////
-        std::array<double,2> begin( {0,0}), end(begin), temp(begin), end_old(end);
+        std::array<double,2> begin( {0,0}), end(begin), temp(begin);
         thrust::host_vector<double> r_old(y_vec.size(), 0), r_diff( r_old);
         thrust::host_vector<double> z_old(y_vec.size(), 0), z_diff( z_old);
         r.resize( y_vec.size()), z.resize(y_vec.size());
@@ -593,7 +593,6 @@ struct InitialX
     {
         //constructor finds four points around X-point and integrates them a bit away from it
         dg::geo::FieldRZtau fieldRZtau_(psi);
-        std::array<double,2> begin( {0,0}), end(begin), temp(begin), end_old(end);
         double eps[] = {1e-11, 1e-12, 1e-11, 1e-12};
         for( unsigned i=0; i<4; i++)
         {

--- a/src/asela/asela.cu
+++ b/src/asela/asela.cu
@@ -4,6 +4,7 @@
 #include <sstream>
 #include <cmath>
 // #define DG_DEBUG
+#include "json/json.h"
 
 #include "draw/host_window.h"
 //#include "draw/device_window.cuh"

--- a/src/asela2D/asela.cu
+++ b/src/asela2D/asela.cu
@@ -3,6 +3,7 @@
 #include <vector>
 #include <sstream>
 #include <cmath>
+#include "json/json.h"
 // #define DG_DEBUG
 
 #include "draw/host_window.h"

--- a/src/asela2D/asela_hpc.cu
+++ b/src/asela2D/asela_hpc.cu
@@ -3,6 +3,7 @@
 #include <vector>
 #include <sstream>
 #include <cmath>
+#include "json/json.h"
 // #define DG_DEBUG
 
 

--- a/src/asela2D/asela_mpi.cu
+++ b/src/asela2D/asela_mpi.cu
@@ -5,6 +5,7 @@
 #include <cmath>
 
 #include <mpi.h> //activate mpi
+#include "json/json.h"
 
 #include "dg/algorithm.h"
 

--- a/src/feltor2D/feltor.cu
+++ b/src/feltor2D/feltor.cu
@@ -3,6 +3,7 @@
 #include <vector>
 #include <sstream>
 #include <cmath>
+#include "json/json.h"
 // #define DG_DEBUG
 
 #include "draw/host_window.h"

--- a/src/feltor2D/feltor_hpc.cu
+++ b/src/feltor2D/feltor_hpc.cu
@@ -3,6 +3,7 @@
 #include <vector>
 #include <sstream>
 #include <cmath>
+#include "json/json.h"
 // #define DG_DEBUG
 
 #include "dg/algorithm.h"

--- a/src/feltor2D/feltor_mpi.cu
+++ b/src/feltor2D/feltor_mpi.cu
@@ -5,6 +5,7 @@
 #include <cmath>
 
 #include <mpi.h> //activate mpi
+#include "json/json.h"
 #include "netcdf_par.h" //exclude if par netcdf=OFF
 
 #include "dg/algorithm.h"

--- a/src/heat/heat.cu
+++ b/src/heat/heat.cu
@@ -4,6 +4,7 @@
 #include <sstream>
 #include <cmath>
 // #define DG_DEBUG
+#include "json/json.h"
 
 #include "draw/host_window.h"
 //#include "draw/device_window.cuh"

--- a/src/heat/heat_hpc.cu
+++ b/src/heat/heat_hpc.cu
@@ -7,6 +7,7 @@
 
 #include <cusp/coo_matrix.h>
 #include <cusp/print.h>
+#include "json/json.h"
 
 #include "file/nc_utilities.h"
 #include "dg/algorithm.h"

--- a/src/polar/polar_mpi.cu
+++ b/src/polar/polar_mpi.cu
@@ -36,17 +36,16 @@ int main(int argc, char* argv[])
     MPI_Comm_size( MPI_COMM_WORLD, &size);
 
     ////Parameter initialisation ////////////////////////////////////////////
-    Json::Reader reader;
     Json::Value js;
     if( argc == 1)
     {
         std::ifstream is("input.json");
-        reader.parse(is,js,false);
+        is >> js;
     }
     else if( argc == 2)
     {
         std::ifstream is(argv[1]);
-        reader.parse(is,js,false);
+        is >> js;
     }
     else
     {
@@ -101,7 +100,7 @@ int main(int argc, char* argv[])
     Karniadakis< MDVec > karniadakis( y0, y0.size(), p.eps_time);
 
     t.tic();
-    shu( y0, y1);
+    shu( 0, y0, y1);
     t.toc();
     if(rank == 0)
         cout << "Time for one rhs evaluation: "<<t.diff()<<"s\n";
@@ -118,7 +117,7 @@ int main(int argc, char* argv[])
     }
 
     double time = 0;
-    karniadakis.init( shu, diffusion, y0, p.dt);
+    karniadakis.init( shu, diffusion, time, y0, p.dt);
 
     t.tic();
     while (time < p.maxout*p.itstp*p.dt)
@@ -132,9 +131,9 @@ int main(int argc, char* argv[])
     }
     t.toc();
 
-    double vorticity_end = blas2::dot( stencil , w2d, ab.last());
-    blas1::pointwiseDot( stencil, ab.last(), ry0);
-    double enstrophy_end = 0.5*blas2::dot( ry0, w2d, ab.last());
+    double vorticity_end = blas2::dot( stencil , w2d, y0);
+    blas1::pointwiseDot( stencil, y0, ry0);
+    double enstrophy_end = 0.5*blas2::dot( ry0, w2d, y0);
     double energy_end    = 0.5*blas2::dot( ry0, w2d, shu.potential()) ;
     if(rank == 0) {
         cout << "Vorticity error           :  "<<vorticity_end-vorticity<<"\n";


### PR DESCRIPTION
Find that when evaluating transcendental functions on gpu directly (blas1::transform, blas1::evaluate) we get yet another result. 
Second, json.h is no longer included by geometries.h in order to fix compilation errors when README is followed to the letter.
Third, began to fix the multiple translation unit problem (if algorithm.h is included by multiple translation units we get serious linker errors, which contradicts the claim that we are header only)
1) add exp test to evaluation_t that explicitly tests evaluation on gpu
2) include json.h manually by asela, feltor, feltor2D, asela2D, heat and polar, all geometries files and feltordiag, filamentdiag, and ncdiag
3) added static keyword to exblas functions and remove including vcl/instrset_detect.cpp, added a value_type to some average templates
4) added more info about json and netcdf installation in README
5) minor corrections in docu