### PR TITLE
HOTFIX: Recursive symv must call itself

### DIFF
--- a/inc/dg/backend/blas2_dispatch_shared.h
+++ b/inc/dg/backend/blas2_dispatch_shared.h
@@ -14,7 +14,7 @@
 ///@cond
 namespace dg{
 namespace blas1{
-//forward declare used blas1 functions
+//forward declare blas1 functions
 template<class from_ContainerType, class to_ContainerType>
 inline void transfer( const from_ContainerType& source, to_ContainerType& target);
 
@@ -24,6 +24,17 @@ template< class ContainerType, class ContainerType1, class ContainerType2>
 inline void pointwiseDot( const ContainerType1& x1, const ContainerType2& x2, ContainerType& y);
 }//namespace blas1
 namespace blas2{
+//forward declare blas2 functions
+template< class MatrixType, class ContainerType1, class ContainerType2>
+inline void symv( get_value_type<ContainerType1> alpha,
+                  MatrixType&& M,
+                  const ContainerType1& x,
+                  get_value_type<ContainerType1> beta,
+                  ContainerType2& y);
+template< class MatrixType, class ContainerType1, class ContainerType2>
+inline void symv( MatrixType&& M,
+                  const ContainerType1& x,
+                  ContainerType2& y);
 namespace detail{
 
 template< class ContainerType1, class MatrixType, class ContainerType2>
@@ -104,7 +115,7 @@ inline void doSymv(
               SharedVectorTag, RecursiveVectorTag)
 {
     for(unsigned i=0; i<x.size(); i++)
-        dg::blas1::pointwiseDot( alpha, std::forward<Matrix>(m), do_get_vector_element(x,i,get_tensor_category<Vector1>()), beta, do_get_vector_element(y,i,get_tensor_category<Vector2>()));
+        dg::blas2::symv( alpha, std::forward<Matrix>(m), do_get_vector_element(x,i,get_tensor_category<Vector1>()), beta, do_get_vector_element(y,i,get_tensor_category<Vector2>()));
 }
 
 template< class Matrix, class Vector1, class Vector2>
@@ -115,7 +126,7 @@ inline void doSymv(
               SharedVectorTag, RecursiveVectorTag)
 {
     for(unsigned i=0; i<y.size(); i++)
-        dg::blas1::pointwiseDot( 1, std::forward<Matrix>(m), do_get_vector_element(x,i,get_tensor_category<Vector1>()), 0, do_get_vector_element(y,i,get_tensor_category<Vector2>()));
+        dg::blas2::symv( std::forward<Matrix>(m), do_get_vector_element(x,i,get_tensor_category<Vector1>()), do_get_vector_element(y,i,get_tensor_category<Vector2>()));
 }
 
 

--- a/inc/dg/blas_mpit.cu
+++ b/inc/dg/blas_mpit.cu
@@ -62,6 +62,9 @@ int main( int argc, char* argv[])
     if(rank==0)std::cout << "Test SYMV functions:\n";
     dg::blas2::symv( 2., arrdvec1, arrdvec1);
     if(rank==0)std::cout << "symv Scalar times Vector          "<<( arrdvec1[0].data()[0] == 52) << std::endl;
+    std::array<std::vector<dg::MDVec>,1> recursive{ arrdvec1};
+    dg::blas2::symv( arrdvec1[0], recursive, recursive);
+    if(rank==0)std::cout << "symv deep Recursion               "<<( recursive[0][0].data()[0] == 52*52) << std::endl;
     MPI_Finalize();
 
     return 0;

--- a/inc/dg/blas_t.cu
+++ b/inc/dg/blas_t.cu
@@ -57,6 +57,9 @@ int main()
     std::cout << "Test SYMV functions:\n";
     dg::blas2::symv( 2., arrdvec1, arrdvec1);
     std::cout << "symv Scalar times Vector          "<<( arrdvec1[0][0] == 52) << std::endl;
+    std::array<std::vector<dg::DVec>,1> recursive{ arrdvec1};
+    dg::blas2::symv( arrdvec1[0], recursive, recursive);
+    std::cout << "symv deep Recursion               "<<( recursive[0][0][0] == 52*52) << std::endl;
 
     return 0;
 }


### PR DESCRIPTION
There is a bug for shared vectors if the
recursion level in symv is deeper than one.
Fix bug and add tests in blas_t and blas_mpit
to detect in the future.