### PR TITLE
HOTFIX recursive and mpi dot product

### DIFF
--- a/inc/dg/backend/blas1_dispatch_vector.h
+++ b/inc/dg/backend/blas1_dispatch_vector.h
@@ -79,9 +79,9 @@ inline std::vector<int64_t> doDot_superacc( const Vector1& x1, const Vector2& x2
         std::vector<int64_t> temp = doDot_superacc( do_get_vector_element(x1,i,get_tensor_category<Vector1>()), do_get_vector_element(x2,i,get_tensor_category<Vector2>()));
         int imin = exblas::IMIN, imax = exblas::IMAX;
         exblas::cpu::Normalize( &(temp[0]), imin, imax);
-        for( int k=exblas::IMIN; k<exblas::IMAX; k++)
+        for( int k=exblas::IMIN; k<=exblas::IMAX; k++)
             acc[k] += temp[k];
-        if( i%128 == 0)
+        if( (i+1)%128 == 0)
         {
             imin = exblas::IMIN, imax = exblas::IMAX;
             exblas::cpu::Normalize( &(acc[0]), imin, imax);

--- a/inc/dg/backend/blas2_dispatch_mpi.h
+++ b/inc/dg/backend/blas2_dispatch_mpi.h
@@ -62,7 +62,7 @@ inline std::vector<int64_t> doDot_superacc( const Vector1& x, const Matrix& m, c
         exblas::cpu::Normalize( &(acc[0][0]), imin, imax);
         imin = exblas::IMIN, imax = exblas::IMAX;
         exblas::cpu::Normalize( &(acc[i][0]), imin, imax);
-        for( int k=exblas::IMIN; k<exblas::IMAX; k++)
+        for( int k=exblas::IMIN; k<=exblas::IMAX; k++)
             acc[0][k] += acc[i][k];
     }
     return acc[0];

--- a/inc/dg/backend/blas2_dispatch_scalar.h
+++ b/inc/dg/backend/blas2_dispatch_scalar.h
@@ -58,7 +58,7 @@ inline std::vector<int64_t> doDot_superacc( const Vector1& x, const Matrix& m, c
         exblas::cpu::Normalize( &(acc[0][0]), imin, imax);
         imin = exblas::IMIN, imax = exblas::IMAX;
         exblas::cpu::Normalize( &(acc[i][0]), imin, imax);
-        for( int k=exblas::IMIN; k<exblas::IMAX; k++)
+        for( int k=exblas::IMIN; k<=exblas::IMAX; k++)
             acc[0][k] += acc[i][k];
     }
     return acc[0];

--- a/inc/dg/backend/blas2_dispatch_shared.h
+++ b/inc/dg/backend/blas2_dispatch_shared.h
@@ -80,7 +80,7 @@ inline std::vector<int64_t> doDot_superacc( const Vector1& x, const Matrix& m, c
         exblas::cpu::Normalize( &(acc[0][0]), imin, imax);
         imin = exblas::IMIN, imax = exblas::IMAX;
         exblas::cpu::Normalize( &(acc[i][0]), imin, imax);
-        for( int k=exblas::IMIN; k<exblas::IMAX; k++)
+        for( int k=exblas::IMIN; k<=exblas::IMAX; k++)
             acc[0][k] += acc[i][k];
     }
     return acc[0];

--- a/inc/dg/backend/blas2_dispatch_vector.h
+++ b/inc/dg/backend/blas2_dispatch_vector.h
@@ -33,9 +33,9 @@ inline std::vector<int64_t> doDot_superacc( const Vector1& x, const Matrix& m, c
         std::vector<int64_t> temp = doDot_superacc( do_get_vector_element(x,i,get_tensor_category<Vector1>()), m[i], do_get_vector_element(y,i,get_tensor_category<Vector2>()));
         int imin = exblas::IMIN, imax = exblas::IMAX;
         exblas::cpu::Normalize( &(temp[0]), imin, imax);
-        for( int k=exblas::IMIN; k<exblas::IMAX; k++)
+        for( int k=exblas::IMIN; k<=exblas::IMAX; k++)
             acc[k] += temp[k];
-        if( i%128 == 0)
+        if( (i+1)%128 == 0)
         {
             imin = exblas::IMIN, imax = exblas::IMAX;
             exblas::cpu::Normalize( &(acc[0]), imin, imax);


### PR DESCRIPTION
forgot last index in for-loop; leads to very peculiar and hard to detect errors in the dot product because most of the times the last index does not matter 