### PR TITLE
Remove Cusp Dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ far away from strictly following it really.
  - All dg functions/classes returning or depending on `cusp::array2d` now use `dg::SquareMatrix`
  - The inverse type of tridiagonal matrices in `dg/matrix/matrix.h` is `dg::SquareMatrix`
 ### Deprecated
+ - `dg::InverseTriDiagonal` because untested and unused over `dg::mat::compute_Tinv_y`
 ### Removed
  - All cusp header files are removed from `dg/algorithm.h`, `dg/geometries/geometries.h` and `dg/matrix/matrix.h` (The relevant tensor traits for cusp can still manually be included though)
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,26 @@ far away from strictly following it really.
 > Only changes in code are reported here, we do not track changes in the
 > doxygen documentation, READMEs or tex writeups.
 > As of v7.0 we also stop reporting changes in test and benchmark programs.
+## [v8.1] Remove cusp dependency
+### Added
+ - New `dg::SparseMatrix` class to replace our previous `cusp::csr_matrix` and `cusp::coo_matrix`
+ - The `SPARSELIB` Makefile variables expands to `-lcusparse` when compiling with cuda
+ - resize method in `dg::TriDiagonal`
+ - Writeable data method in `dg::SquareMatrix`
+### Changed
+ - The `LIBS` Makefile variable includes `-lcusparse` dependency when compiling with cuda. This is rather trivial because cuda ships with cusparse.
+ - Default build should now use `https://github.com/nvidia/cccl` repository
+ - Default build should now use `https://github.com/vectorclass/version2` (instead of version1)
+ - All dg functions/classes/typedefs returning or depending on any cusp coo or csr matrix now use `dg::SparseMatrix`
+ - All dg functions/classes returning or depending on `cusp::dia_matrix` now use `dg::TriDiagonal`
+ - All dg functions/classes returning or depending on `cusp::array1d` now use `thrust::host_vector`
+ - All dg functions/classes returning or depending on `cusp::array2d` now use `dg::SquareMatrix`
+ - The inverse type of tridiagonal matrices in `dg/matrix/matrix.h` is `dg::SquareMatrix`
+### Deprecated
+### Removed
+ - All cusp header files are removed from `dg/algorithm.h`, `dg/geometries/geometries.h` and `dg/matrix/matrix.h` (The relevant tensor traits for cusp can still manually be included though)
+### Fixed
+ - Thrust library can now be used at newest version
 
 ## [v8.0] Improved foundations
 ### Added

--- a/README.adoc
+++ b/README.adoc
@@ -47,24 +47,20 @@ Open a terminal and clone the repository into any folder you like
 git clone https://www.github.com/feltor-dev/feltor
 ----
 
-You also need to clone https://github.com/nvidia/thrust[thrust] and
-https://github.com/cusplibrary/cusplibrary[cusp] distributed under the
+You also need to clone https://github.com/nvidia/cccl[cccl]
+ distributed under the
 Apache-2.0 license. Also, we need Agner Fog's https://github.com/vectorclass/version1[vcl] library (Apache 2.0). So again in a folder of your choice
 
 [source,sh]
 ----
-git clone https://www.github.com/nvidia/thrust
-git clone https://www.github.com/cusplibrary/cusplibrary
-git clone https://www.github.com/vectorclass/version1 vcl
-# We need to checkout an older version of thrust compatible with cusp
-cd thrust
-git checkout 1.9.3
+git clone https://www.github.com/nvidia/cccl
+git clone https://www.github.com/vectorclass/version2 vcl
 ----
 
 ____
 Our code only depends on external libraries that are themselves openly
 available.
- We use version1 of the vectorclass library, as version2 requires C{plus}{plus}-17 and does not work with the intel compiler.
+If version2 of the vectorclass library does not work for you, you can also try version1.
 ____
 
 .System requirements [[tab_requirements]]
@@ -73,15 +69,15 @@ ____
 |=======================================================================
 |    | Minimum system requirements  | Recommended system requirements
 | *CPU*     | Any         |support for AVX and FMA instruction set
-| *Compiler*| gcc-5.1 or msvc-15 or icc-17.0 (C{plus}{plus}-17 standard)| gcc-9.3, OpenMP-4 support, avx, fma instruction set flags
-| *GPU*     | - | NVidia GPU with compute-capability > 6 and nvcc-11.0
+| *Compiler*| gcc >= 9 or msvc >= 19 or icc >= 19.0 (C{plus}{plus}-17 standard)| OpenMP-4 support, avx, fma instruction set flags
+| *GPU*     | - | NVidia GPU with compute-capability >= 6.1 and nvcc >= 11.0
 | *MPI*     | - | mpi installation compatible with compiler (ideally cuda-aware in case hybrid MPI+GPU is the target system)
 |=======================================================================
 ____
 Our GPU backend uses the
 https://developer.nvidia.com/cuda-zone[Nvidia-CUDA] programming
 environment and in order to compile and run a program for a GPU a user
-needs at least the nvcc-8.0 compiler (available free of charge) and a NVidia
+needs at least the nvcc-11.0 compiler (available free of charge) and a NVidia
 GPU. However, we explicitly note here that due to the modular design of
 our software a user does not have to possess a GPU nor the nvcc
 compiler. The CPU version of the backend is equally valid and provides
@@ -103,8 +99,10 @@ directory
 cd ~
 mkdir include
 cd include
-ln -s path/to/thrust/thrust # Yes, thrust is there twice!
-ln -s path/to/cusplibrary/cusp
+ln -s path/to/cccl/thrust/thrust # Yes, thrust is there twice!
+ln -s path/to/cccl/cub/cub
+ln -s path/to/cccl/libcudacxx/include/cuda
+ln -s path/to/cccl/libcudacxx/include/nv
 ln -s path/to/vcl
 ----
 
@@ -404,10 +402,8 @@ Please clone all four of the following URLs using `File -> Clone repository...`
 [source,sh]
 ----
 https://www.github.com/feltor-dev/feltor
-https://www.github.com/nvidia/thrust
-# Checkout thrust to 1.9.3
-https://www.github.com/cusplibrary/cusplibrary
-https://www.github.com/vectorclass/version1 # local path "vcl"
+https://www.github.com/nvidia/cccl
+https://www.github.com/vectorclass/version2 # local path "vcl"
 ----
 Please also have a look at the relevant <<tab_requirements, system requirements>> Table.
 
@@ -421,8 +417,8 @@ the FELTOR library headers `dg/algorithm.h` and/or `dg/geometries/geometries.h`
 to a convenient location.
 * Double click on `FeltorPropertySheet` (expand your solution and any of the Debug or Release tabs to find it)
 ** In `VC++ Directories -> Include Directories` click on `Edit` Then add the four lines
-`path\to\feltor\inc`, `path\to\thrust`,
-`path\to\cusplibrary` and `path\to\folder_containing_vcl`
+`path\to\feltor\inc`, `path\to\cccl\thrust`,
+`path\to\cccl\cub`, `path\to\cccl\libcudacxx\include`  and `path\to\folder_containing_vcl`
 ** In `C/C++ -> Optimization -> Enable Intrinsic Functions` select `Yes (/Oi)`
 ** In `C/C++ -> Preprocessor -> Preprocessor Definitions` select `Edit` and
 add the line `THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CPP` (Selects the CPU backend in FELTOR)
@@ -494,34 +490,17 @@ LaTeX::
 Install https://miktex.org/[MikTex] and https://texstudio.org[TeXstudio] (in that order) in order to be able to
 compile the tex file(s) of the documentation.
 
-=== Troubleshooting [[sec_troubleshooting]]
-==== I get a compile error: identifier "__thrust_compiler_fence" is undefined
-
-This is an error of the unmaintained cusp that does not like the newly
-updated thrust version on github. Currently, you can either go back to
-version 1.9.3 in thrust:
-
-```sh
-cd path/to/thrust
-git checkout 1.9.3
-```
-or alternatively there is a fix in cusp that can be accessed via
-```sh
-cd path/to/cusplibrary
-git checkout cuda10
-```
 == 2. Documentation
 
 The
-https://mwiesenberger.github.io/feltor/dg/html/modules.html[documentation]
+https://mwiesenberger.github.io/feltor/dg/html/topics.html[documentation]
 of the dg library was generated with
-http://www.doxygen.org[Doxygen] and LateX. You can generate a local
+http://www.doxygen.org[Doxygen]. You can generate a local
 version directly from source code. This depends on the `doxygen`,
-`libjs-mathjax` and `graphviz` packages and LateX (for equations). Type `make doc` in
+`libjs-mathjax`, `graphviz` and `doxygen-awesome` packages. Type `make doc` in
 the folder `path/to/feltor/doc` and open `index.html` (a symbolic link
 to `dg/html/modules.html`) with your favorite browser.
-Finally, also note the documentations of https://thrust.github.io/doc/modules.html[thrust]
-and https://cusplibrary.github.io/[cusp].
+Finally, also note the documentations of https://nvidia.github.io/cccl/thrust[thrust].
 
 We maintain tex files in every src folder for
 technical documentation, which can be compiled using pdflatex with

--- a/config/README.md
+++ b/config/README.md
@@ -30,7 +30,7 @@ Within the file you can overwrite or add to any of the following variables:
 |   NVCC    | nvcc                                     | CUDA compiler                            |
 | NVCCFLAGS | -std=c++17  -Xcompiler "-Wall -mavx -mfma"                             | flags for nvcc  and underlying host compiler, (minimum instruction set is sse4.1, avx and fma are recommended)                         |
 | NVCCARCH  | -arch sm_61                              | specify the **gpu** compute capability  https://developer.nvidia.com/cuda-gpus (note: can be overwritten on the command line) |
-|  INCLUDE  | -I$(HOME)/include                        | cusp, thrust, vcl and the draw (if needed) libraries. The default expects to find (symbolic links to ) these libraries in your home folder |
+|  INCLUDE  | -I$(HOME)/include                        | thrust, cub, cuda, nv vcl and the draw (if needed) libraries. The default expects to find (symbolic links to ) these libraries in your home/include folder |
 |   LIBS    | -lnetcdf -lhdf5_serial -ldhf5_serial_hl                | netcdf and hdf5 library. Normally, we would use -lhdf5 and -lhdf5_hl but the libhdf5-dev package installs them with "_serial". |
 |  JSONLIB  | -ljsoncpp          | the JSON library, the default is assumed to be jsoncpp; if instead `-DDG_USE_JSONHPP` is set then the (header-only) nlohmann-json library is used                       |
 |  LAPACKLIB  | -llapacke | the lapack library                      |
@@ -41,7 +41,7 @@ The main purpose of the file `feltor/config/devices/devices.mk` is to configure 
 
 | value | description                                                  | flags                                                        |
 | ----- | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| gpu   | replaces the CC and CFLAGS variables with the nvcc versions and analogously MPICC and MPICFLAGS | `CC = $(NVCC) -x cu --compiler-bindir $(CC)` `CFLAGS = $(NVCCARCH) $(NVCCFLAGS)` `MPICC = $(NVCC) -x cu --compiler-bindir $(MPICC)` `MPICFLAGS+= $(NVCCARCH) $(NVCCFLAGS)` |
+| gpu   | replaces the CC and CFLAGS variables with the nvcc versions and analogously MPICC and MPICFLAGS, Add `-lcusparse` to `LIBS` | `CC = $(NVCC) -x cu --compiler-bindir $(CC)` `CFLAGS = $(NVCCARCH) $(NVCCFLAGS)` `MPICC = $(NVCC) -x cu --compiler-bindir $(MPICC)` `MPICFLAGS+= $(NVCCARCH) $(NVCCFLAGS)` |
 | omp   | all thrust device calls redirect to OpenMP using the THRUST_DEVICE_SYSTEM macro | `CFLAGS += -x c++ -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_OMP  $(OMPFLAG)`, `MPICFLAGS+=$(CFLAGS)` |
 | cpu   | all thrust device calls redirect to single thread version using the THRUST_DEVICE_SYSTEM macro | `CFLAGS += -x c++ -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CPP`, `MPICFLAGS+=$(CFLAGS)` |
 | knl   | same as omp but specifies OPT for Intel Xeon Phi architecture | `OPT = -O3 -xMIC-AVX512`                                     |

--- a/config/devices/devices.mk
+++ b/config/devices/devices.mk
@@ -2,7 +2,9 @@ ifeq ($(strip $(device)),gpu)
 ccc_:=$(CC)
 CC = $(NVCC) --compiler-bindir $(ccc_)
 CFLAGS = -x cu $(NVCCARCH) $(NVCCFLAGS)
-SPARSELIB=-lcusparse
+# We put cusparse both in LIBS as well as a separate SPARSELIB
+SPARSELIB= -lcusparse
+LIBS+=$(SPARSELIB)
 # 21.1.25 commented out next 2 lines
 # Seems to work, shouldn't have any performance issues!?
 #CFLAGS+=-D_FORCE_INLINES # solves issue with std=c++11

--- a/config/devices/devices.mk
+++ b/config/devices/devices.mk
@@ -2,6 +2,7 @@ ifeq ($(strip $(device)),gpu)
 ccc_:=$(CC)
 CC = $(NVCC) --compiler-bindir $(ccc_)
 CFLAGS = -x cu $(NVCCARCH) $(NVCCFLAGS)
+SPARSELIB=-lcusparse
 # 21.1.25 commented out next 2 lines
 # Seems to work, shouldn't have any performance issues!?
 #CFLAGS+=-D_FORCE_INLINES # solves issue with std=c++11

--- a/config/leonardo.mk
+++ b/config/leonardo.mk
@@ -13,14 +13,14 @@ LIBS    +=-L$(NETCDF_C_LIB) -lnetcdf -lcurl
 #LAPACKLIB = -L$(LAPACK_LIB) -llapacke
 endif
 #########################Modules to load ##################
-# module load gcc/11.3.0
-# module load cuda/11.8
+# module load gcc/12.2
+# module load cuda/12.1
 # 
 # module load spack
 # # spack list jsoncpp
 # # spack spec -Il jsoncpp
-# # spack install jsoncpp %gcc@11.3.0
-# spack load jsoncpp
+# # spack install jsoncpp %gcc@12.2.0
+# spack load jsoncpp%gcc@12.2.0
 # module load openmpi/4.1.4--gcc--11.3.0-cuda-11.8
 # module load boost/1.80.0--gcc--11.3.0
 # module load hdf5/1.12.2--gcc--11.3.0

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -33,9 +33,9 @@
 ###
 
 # doxygen-awesome-css path
-#  if installed via system package manager
+# If installed via system package manager:
 #dapath=/usr/share/doxygen-awesome-css
-# installed via make install
+# If installed via make install:
 dapath=/usr/local/share/doxygen-awesome-css
 # Relative paths won't work!!
 #dapath=../../doxygen-awesome-css

--- a/inc/dg/Makefile
+++ b/inc/dg/Makefile
@@ -39,10 +39,10 @@ mpi_blas1_t\
 all: $(CPPFILES:%.cpp=%) $(CUFILES:%.cu=%)
 
 %_mpib: %_b.cpp
-	$(MPICC) $(OPT) $(MPICFLAGS) $< -o $@ $(INCLUDE) -DWITH_MPI
+	$(MPICC) $(OPT) $(MPICFLAGS) $< -o $@ $(INCLUDE) -DWITH_MPI $(SPARSELIB)
 
 %_b: %_b.cpp
-	$(CC) $(OPT) $(CFLAGS) $< -o $@ $(INCLUDE) -g
+	$(CC) $(OPT) $(CFLAGS) $< -o $@ $(INCLUDE) -g $(SPARSELIB)
 
 %_t.$(device).o: %_t.cpp %.h
 	$(CC) $(OPT) $(CFLAGS) -c $< -o $@ -g $(INCLUDE)
@@ -51,10 +51,10 @@ mpi_%_t.$(device).o: %_t.cpp
 	$(MPICC) $(OPT) $(MPICFLAGS) -c $< -o $@ -g $(INCLUDE) -DWITH_MPI
 
 %_t: $(CATCH).$(device).o %_t.$(device).o
-	$(CC) $(OPT) -o $@ $^ -lCatch2
+	$(CC) $(OPT) -o $@ $^ -lCatch2 $(SPARSELIB)
 
 mpi_%_t: $(CATCHMPI).$(device).o mpi_%_t.$(device).o
-	$(MPICC) $(OPT) -o $@ $^ -lCatch2
+	$(MPICC) $(OPT) -o $@ $^ -lCatch2 $(SPARSELIB)
 
 $(CATCH).$(device).o: $(CATCH).cpp
 	$(CC) $(OPT) $(CFLAGS) $(INCLUDE) -g -c $< -o $@
@@ -63,10 +63,10 @@ $(CATCHMPI).$(device).o: $(CATCHMPI).cpp
 	$(MPICC) $(OPT) $(MPICFLAGS) $(INCLUDE) -g -c $< -o $@
 
 tests: $(CATCH).$(device).o $(addsuffix .$(device).o,$(TARGETS))
-	$(CC) -o $@ $^ -lCatch2
+	$(CC) -o $@ $^ -lCatch2 $(SPARSELIB)
 
 mpi-tests: $(CATCHMPI).$(device).o $(addsuffix .$(device).o,$(TARGETSMPI))
-	$(MPICC) -o $@ $^ -lCatch2
+	$(MPICC) -o $@ $^ -lCatch2 $(SPARSELIB)
 
 .PHONY: clean doc
 

--- a/inc/dg/backend/Makefile
+++ b/inc/dg/backend/Makefile
@@ -12,7 +12,8 @@ TARGETS=fma_t\
 index_t\
 memory_t\
 traits_t\
-view_t
+view_t\
+sparsematrix_t
 
 TARGETSMPI=mpi_gather_kron_mpit\
 mpi_gather_mpit\

--- a/inc/dg/backend/Makefile
+++ b/inc/dg/backend/Makefile
@@ -40,10 +40,10 @@ version: version.cpp
 	./$@
 
 %_t: $(CATCH).$(device).o %_t.$(device).o
-	$(CC) $(OPT) -o $@ $^ -lCatch2
+	$(CC) $(OPT) -o $@ $^ -lCatch2 $(SPARSELIB)
 
 %_mpit: $(CATCHMPI).$(device).o %_mpit.$(device).o
-	$(MPICC) $(OPT) -o $@ $^ -lCatch2
+	$(MPICC) $(OPT) -o $@ $^ -lCatch2 $(SPARSELIB)
 
 $(CATCH).$(device).o: $(CATCH).cpp
 	$(CC) $(OPT) $(CFLAGS) $(INCLUDE) -g -c $< -o $@
@@ -52,10 +52,10 @@ $(CATCHMPI).$(device).o: $(CATCHMPI).cpp
 	$(MPICC) $(OPT) $(MPICFLAGS) $(INCLUDE) -g -c $< -o $@
 
 tests: $(CATCH).$(device).o $(addsuffix .$(device).o,$(TARGETS))
-	$(CC) -o $@ $^ -lCatch2
+	$(CC) -o $@ $^ -lCatch2 $(SPARSELIB)
 
 mpi-tests: $(CATCHMPI).$(device).o $(addsuffix .$(device).o,$(TARGETSMPI))
-	$(MPICC) -o $@ $^ -lCatch2
+	$(MPICC) -o $@ $^ -lCatch2 $(SPARSELIB)
 
 .PHONY: clean
 

--- a/inc/dg/backend/blas2_cusp.h
+++ b/inc/dg/backend/blas2_cusp.h
@@ -150,7 +150,7 @@ inline void doStencil(
     dg::blas2::parallel_for( f, m.num_rows, m.row_offsets, m.column_indices, m.values, x, y);
 }
 template< class Functor, class Matrix, class Vector1, class Vector2>
-inline void doSymv( get_value_type<Vector1> alpha,
+inline void doStencil( get_value_type<Vector1> alpha,
                     Functor f,
                     Matrix&& m,
                     const Vector1&x,

--- a/inc/dg/backend/blas2_sparseblockmat.h
+++ b/inc/dg/backend/blas2_sparseblockmat.h
@@ -34,10 +34,10 @@ inline void doSymv_dispatch(
 
     int size_x = x.size();
     int size_y = y.size();
-    if( size_x != m.total_num_cols()) {
+    if( (size_t)size_x != (size_t)m.total_num_cols()) {
         throw Error( Message(_ping_)<<"x has the wrong size "<<x.size()<<" Number of columns is "<<m.total_num_cols());
     }
-    if( size_y != m.total_num_rows()) {
+    if( (size_t)size_y != (size_t)m.total_num_rows()) {
         throw Error( Message(_ping_)<<"y has the wrong size "<<y.size()<<" Number of rows is "<<m.total_num_rows());
     }
     const value_type * x_ptr = thrust::raw_pointer_cast(x.data());
@@ -143,7 +143,7 @@ inline void doStencil(
     static_assert( std::is_base_of<SharedVectorTag, get_tensor_category<Vector2>>::value,
         "All data layouts must derive from the same vector category (SharedVectorTag in this case)!");
     static_assert( std::is_same< get_execution_policy<Vector1>, get_execution_policy<Vector2> >::value, "Execution policies must be equal!");
-    typedef typename std::decay_t<Matrix>::value_type value_type;
+    using value_type = dg::get_value_type<Matrix>;
     static_assert( std::is_same< get_value_type<Vector1>, value_type >::value,
         "Value types must be equal"
     );

--- a/inc/dg/backend/index.h
+++ b/inc/dg/backend/index.h
@@ -128,7 +128,7 @@ Unique<typename host_vector::value_type> find_unique_order_preserving(
     std::vector<std::vector<int>> sort; // gather sorted from unsorted elements
     for( unsigned u=0; u<unsorted_elements.size(); u++)
     {
-        auto it =std::find( uni.unique.begin(),
+        auto it =thrust::find( uni.unique.begin(),
                 uni.unique.end(), unsorted_elements[u]);
         if(  it == uni.unique.end()) // not found
         {

--- a/inc/dg/backend/index.h
+++ b/inc/dg/backend/index.h
@@ -7,7 +7,6 @@
 #include "tensor_traits.h"
 #include "tensor_traits_scalar.h"
 #include "tensor_traits_thrust.h"
-#include "tensor_traits_cusp.h"
 #include "tensor_traits_std.h"
 
 namespace dg

--- a/inc/dg/backend/matrix_categories.h
+++ b/inc/dg/backend/matrix_categories.h
@@ -31,6 +31,8 @@ struct CuspMatrixTag: public AnyMatrixTag {};
 struct MPIMatrixTag: public AnyMatrixTag {};
 /// indicate our sparse block matrix format
 struct SparseBlockMatrixTag: public AnyMatrixTag {};
+/// indicate our sparse matrix format
+struct SparseMatrixTag: public SparseBlockMatrixTag {};
 /// indicate our dense matrix format
 struct DenseMatrixTag: public AnyMatrixTag {};
 

--- a/inc/dg/backend/mpi_matrix.h
+++ b/inc/dg/backend/mpi_matrix.h
@@ -117,8 +117,7 @@ mpi matrix to a row distributed mpi matrix. In code
     dg::IHMatrix matrix;
     //...
     // Suppose we have row distributed matrix with local rows and global cols
-    dg::IHMatrix matrixT;
-    cusp::transpose( matrix, matrixT);
+    dg::IHMatrix matrixT= matrix.transpose();
     // matrixT is column distributed
     // matrixT has global rows and local column indices
     dg::convertLocal2GlobalCols( matrixT, grid);
@@ -503,7 +502,7 @@ struct MPIDistMat
 
         using value_type = dg::get_value_type<ContainerType1>;
         m_recv_buffer.template set<value_type>( m_g.buffer_size());
-        m_comp_buffer.template set<value_type>( m_o.num_rows);
+        m_comp_buffer.template set<value_type>( m_o.num_rows());
         auto& recv_buffer = m_recv_buffer.template get<value_type>();
         auto& comp_buffer = m_comp_buffer.template get<value_type>();
 
@@ -554,7 +553,7 @@ struct MPIDistMat
 
         using value_type = dg::get_value_type<ContainerType1>;
         m_recv_buffer.template set<value_type>( m_g.buffer_size());
-        m_comp_buffer.template set<value_type>( m_o.num_rows);
+        m_comp_buffer.template set<value_type>( m_o.num_rows());
         auto& recv_buffer = m_recv_buffer.template get<value_type>();
         auto& comp_buffer = m_comp_buffer.template get<value_type>();
 

--- a/inc/dg/backend/mpi_permutation.h
+++ b/inc/dg/backend/mpi_permutation.h
@@ -6,7 +6,6 @@
 #include "tensor_traits.h"
 #include "tensor_traits_scalar.h"
 #include "tensor_traits_thrust.h"
-#include "tensor_traits_cusp.h"
 #include "tensor_traits_std.h"
 
 

--- a/inc/dg/backend/predicate.h
+++ b/inc/dg/backend/predicate.h
@@ -77,7 +77,7 @@ constexpr bool is_vector_v = is_vector<T, Tag>::value;
 template< class T, class Tag = AnyMatrixTag>
 constexpr bool is_matrix_v = is_matrix<T, Tag>::value;
 
-/// @brief Does a type have a execution_policy derived from \c Tag
+/// @brief Does a type have an execution_policy equal to \c Tag
 /// @sa dg::has_policy_v
 template< class T, class Tag = AnyPolicyTag>
 using has_policy = std::is_same<Tag, get_execution_policy<T>>;

--- a/inc/dg/backend/sparsematrix.h
+++ b/inc/dg/backend/sparsematrix.h
@@ -70,25 +70,75 @@ I coo2csr( unsigned num_rows, const I& coo)
 }
 }
 
-// Type of Index can be int or long
+/*! @brief A CSR formatted sparse matrix
+ *
+ * This class was designed to replace our dependency on \c cusp::csr_matrix. On
+ * the host arithmetic operators like + and \* are overloaded allowing for
+ * expressive code to concisely assemble the matrix:
+ * @snippet{trimleft} sparsematrix_t.cpp summary
+ *
+ * On the device like OpenMP or GPU the only currently allowed operations are \c transpose and the
+ * matrix-vector multiplications through \c dg::blas2::symv (and its aliases \c
+ * dg::blas2::gemv and \c dg::apply). We use the \c cusparse library to dispatch matrix-vector
+ * multiplication on the GPU.
+ * @sa The CSR format is nicely explained at the
+ * <a href="https://docs.nvidia.com/cuda/cusparse/#compressed-sparse-row-csr">cusparse documentation</a>
+ * We use the zero-base index
+ *
+ * @tparam Index The index type (on GPU must be either \c int or \c long)
+ * @tparam Value The value type (on GPU must be either \c float or \c double)
+ * @tparam Vector The vector class to store indices and values (typically \c thrust::host_vector or \c thrust::device_vector)
+ * @sa \c IHMatrix, \c IDMatrix
+ * @ingroup sparsematrix
+ */
 template<class Index = int, class Value = double, template<class> class Vector = thrust::host_vector>
 struct SparseMatrix
 {
-    using policy = dg::get_execution_policy<Vector<Value>>;
-    using index_type = Index;
-    using value_type = Value;
+    using policy = dg::get_execution_policy<Vector<Value>>; //!< Execution policy of the matrix
+    using index_type = Index; //!< The index type (on GPU must be either \c int or \c long)
+    using value_type = Value; //!< The value type (on GPU must be either \c float or \c double)
+
+    /// A static guard to allow certain members only on host (for serial execution)
     template<class OtherMatrix>
     using enable_if_serial = std::enable_if_t<std::is_same_v<typename OtherMatrix::policy, SerialTag>, OtherMatrix>;
 
+    /*! @brief Empty matrix
+     *
+     * Set values using either \c setFromCoo or \c set members
+     */
     SparseMatrix() = default;
-    // Sort is somewhat expensive and it is allowed to have unsorted column indices (at least in cusparse; for our stencil we also rely on keeping unsorted indices)
-    SparseMatrix( size_t num_rows, size_t num_cols, Vector<Index> row_offsets, Vector<Index> cols, Vector<Value> vals)
-    : m_num_rows( num_rows), m_num_cols( num_cols), m_row_offsets( row_offsets), m_cols(cols), m_vals(vals)
+    // MW: Allowing unsored indices in row is important for our stencils
+    /*! @brief Directly construct from given vectors
+     *
+     * @snippet{trimleft} sparsematrix_t.cpp csr_ctor
+     * @param num_rows Number of rows in the matrix
+     * @param num_cols Number of columns in the matrix
+     * @param row_offsets Vector of size <tt>num_rows+1</tt> representing the
+     * starting position of each row in the column_indices and values arrays.
+     * <tt>row_offsets.back()</tt> equals the number of non-zero elements in
+     * the matrix
+     * @param column_indices Vector of size <tt>row_offsets.back()</tt> containing column indices.
+     * The column indices may be unsorted within each row and should be unique.
+     * If duplicates exist symv may not be correct (from cusparse).
+     * @param values Vector of size <tt>row_offsets.back()</tt> containing nonzero values
+     */
+    SparseMatrix( size_t num_rows, size_t num_cols, const Vector<Index>&
+        row_offsets, const Vector<Index>& column_indices, const Vector<Value>& values)
+    : m_num_rows( num_rows), m_num_cols( num_cols), m_row_offsets(
+    row_offsets), m_cols(column_indices), m_vals(values)
     {
     }
 
+    /// Enable copy constructor from foreign types
     template< class I, class V, template<class> class Vec>
     friend class SparseMatrix; // enable copy
+
+    /*! @brief Copy construct from differen type
+     *
+     * Typically used to transfer a matrix from host to device
+     * @snippet{trimleft} sparsematrix_t.cpp host2device
+     * @param src Copy the matrix
+     */
     template< class I, class V, template<class> class Vec>
     SparseMatrix( const SparseMatrix<I,V,Vec>& src)
     : m_num_rows( src.m_num_rows), m_num_cols( src.m_num_cols), m_row_offsets(
@@ -97,81 +147,162 @@ struct SparseMatrix
     }
 
 
-    // May be unsorted; if duplicates exist symv may not be correct (from cusparse)
-    // if sort sorts by row and column
-    void setFromCoo( size_t num_rows, size_t num_cols, const Vector<Index>& rows, const Vector<Index>& cols, const Vector<Value>& vals, bool sort = false)
+    /*! @brief Set csr values from coo formatted sparse matrix
+     *
+     * @snippet{trimleft} sparsematrix_t.cpp setFromCoo
+     * @note May be unsorted, in which case the \c sort parameter should be set
+     * to \c true; if duplicates exist symv may not be correct (from cusparse)
+     *
+     * @param num_rows Number of rows in the matrix
+     * @param num_cols Number of columns in the matrix
+     * @param row_indices Contains row indices of the corresponding elements in
+     * the values vector
+     * @param column_indices Vector of size <tt>row_indices.size()()</tt>
+     * containing column indices.
+     * @param values Vector of size <tt>row_indices.size()</tt> containing
+     * nonzero values
+     * @param sort If \c true the given vectors are sorted by row and column
+     * before converted to the csr format. Per default we assume that the values
+     * are sorted by row (not necessarily by column). In this case there is no
+     * need to sort the indices, which may be somewhat expensive. If the row
+     * indices are unsorted however, \c sort must be set to \c true  otherwise
+     * the coo2csr conversion will fail.
+    */
+    void setFromCoo( size_t num_rows, size_t num_cols, const Vector<Index>& row_indices, const Vector<Index>& column_indices, const Vector<Value>& values, bool sort = false)
     {
-        if( rows.size() != vals.size())
+        if( row_indices.size() != values.size())
             throw dg::Error( dg::Message( _ping_) << "Error: Row indices size "
-                <<rows.size()<<" not equal to values size "<<vals.size()<<"\n");
-        if( cols.size() != vals.size())
+                <<row_indices.size()<<" not equal to values size "<<values.size()<<"\n");
+        if( column_indices.size() != values.size())
             throw dg::Error( dg::Message( _ping_) << "Error: Column indices size "
-                <<cols.size()<<" not equal to values size "<<vals.size()<<"\n");
+                <<column_indices.size()<<" not equal to values size "<<values.size()<<"\n");
         m_num_rows = num_rows;
         m_num_cols = num_cols;
 
         m_row_offsets.resize( num_rows+1);
-        m_cols.resize( cols.size());
-        m_vals.resize( vals.size());
+        m_cols.resize( column_indices.size());
+        m_vals.resize( values.size());
 
         if( sort)
         {
-            Vector<Index> trows( rows);
-            Vector<Index> tcols( cols);
-            Vector<Index> p( rows.size()); // permutation
+            Vector<Index> trows( row_indices);
+            Vector<Index> tcols( column_indices);
+            Vector<Index> p( row_indices.size()); // permutation
             thrust::sequence( p.begin(), p.end());
             // First sort columns
             thrust::sort_by_key( tcols.begin(), tcols.end(), p.begin());
             // Repeat sort on rows
-            thrust::gather( p.begin(), p.end(), rows.begin(), trows.begin());
+            thrust::gather( p.begin(), p.end(), row_indices.begin(), trows.begin());
             // Now sort rows preserving relative ordering
             thrust::stable_sort_by_key( trows.begin(), trows.end(), p.begin());
             m_row_offsets.resize( num_rows+1);
             detail::coo2csr_inline( trows, m_row_offsets);
             // Repeat sort on cols and vals
-            thrust::gather( p.begin(), p.end(), cols.begin(), m_cols.begin());
-            thrust::gather( p.begin(), p.end(), vals.begin(), m_vals.begin());
+            thrust::gather( p.begin(), p.end(), column_indices.begin(), m_cols.begin());
+            thrust::gather( p.begin(), p.end(), values.begin(), m_vals.begin());
         }
         else
         {
-            detail::coo2csr_inline( rows, m_row_offsets);
-            thrust::copy( cols.begin(), cols.end(), m_cols.begin());
-            thrust::copy( vals.begin(), vals.end(), m_vals.begin());
+            detail::coo2csr_inline( row_indices, m_row_offsets);
+            thrust::copy( column_indices.begin(), column_indices.end(), m_cols.begin());
+            thrust::copy( values.begin(), values.end(), m_vals.begin());
         }
         m_cache.forget();
     }
 
-    // May be unsorted; if duplicates exist symv may not be correct (from cusparse)
-    // if sort sorts by row and column
-    void set( size_t num_rows, size_t num_cols, const Vector<Index>& row_offsets, const Vector<Index> cols, const Vector<Value>& vals, bool sort = false)
+    /*! @brief Set csr values directly
+     *
+     * @snippet{trimleft} sparsematrix_t.cpp set
+     *
+     * @param num_rows Number of rows in the matrix
+     * @param num_cols Number of columns in the matrix
+     * @param row_offsets Vector of size <tt>num_rows+1</tt> representing the
+     * starting position of each row in the column_indices and values arrays.
+     * <tt>row_offsets.back()</tt> equals the number of non-zero elements in
+     * the matrix
+     * @param column_indices Vector of size <tt>row_offsets.back()</tt> containing column indices.
+     * The column indices may be unsorted within each row and should be unique.
+     * If duplicates exist symv may not be correct (from cusparse).
+     * @param values Vector of size <tt>row_offsets.back()</tt> containing nonzero values
+     * @param sort If \c true the given vectors are sorted by column_indices in each row.
+     * It is allowed to have unsorted column indices in each row so sorting is not strictly
+     * necessary. It may (or may not) have an effect on performance.
+    */
+    void set( size_t num_rows, size_t num_cols, const Vector<Index>& row_offsets, const Vector<Index> column_indices, const Vector<Value>& values, bool sort = false)
     {
         if ( sort)
         {
             Vector<Index> rows = detail::csr2coo( row_offsets);
-            setFromCoo( num_rows, num_cols, rows, cols, vals, true);
+            setFromCoo( num_rows, num_cols, rows, column_indices, values, true);
         }
         else
         {
             m_num_rows = num_rows, m_num_cols = num_cols;
-            m_row_offsets = row_offsets, m_cols = cols, m_vals = vals;
+            m_row_offsets = row_offsets, m_cols = column_indices, m_vals = values;
         }
         m_cache.forget();
     }
 
-    size_t total_num_rows() const { return m_num_rows;}
-    size_t total_num_cols() const { return m_num_cols;}
-    size_t num_entries() const { return m_vals.size();}
+    /*! @brief Sort by row and column
+     *
+     * Sort is somewhat expensive and it is allowed to have unsorted column
+     * indices (at least in cusparse). Sorting may or may not have an influence
+     * on performance. Never sort a stencil for \c dg::blas2::stencil.
+     */
+    void sort_indices()
+    {
+        if( m_num_rows != m_row_offsets.size()-1)
+            throw dg::Error( dg::Message( _ping_) << "Error: Row offsets have size "
+                <<m_row_offsets.size()<<" but num_rows is "<<m_num_rows<<"\n");
+        if( m_cols.size() != m_vals.size())
+            throw dg::Error( dg::Message( _ping_) << "Error: Column indices size "
+                <<m_cols.size()<<" not equal to values size "<<m_vals.size()<<"\n");
+
+        // Sort each row
+        Vector<Index> rows = detail::csr2coo( m_row_offsets);
+        Vector<Index> cols = m_cols;
+        Vector<Value> vals = m_vals;
+        setFromCoo( m_num_rows, m_num_cols, rows, cols, vals, true);
+    }
+
+    /// Alias for \c num_rows
+    size_t total_num_rows() const { return m_num_rows;} // for blas2_sparseblockmat dispatch
+    /// Alias for \c num_cols
+    size_t total_num_cols() const { return m_num_cols;} // for blas2_sparseblockmat dispatch
+
+    /// Number of rows in matrix
     size_t num_rows() const { return m_num_rows;}
+    /// Number of columns in matrix
     size_t num_cols() const { return m_num_cols;}
+    /// Alias for \c num_nnz
     size_t num_vals() const { return m_vals.size();}
+    /// Number of nonzero elements in matrix
+    size_t num_nnz() const { return m_vals.size();}
+    /// Alias for \c num_nnz
+    size_t num_entries() const { return m_vals.size();}
+
+    /*! @brief Read row_offsets vector
+     * @return row_offsets
+     */
     const Vector<Index> & row_offsets() const { return m_row_offsets;}
+    /*! @brief Read column indices vector
+     * @return column indices
+     */
     const Vector<Index> & column_indices() const { return m_cols;}
+    /*! @brief Read values vector
+     * @return values
+     */
     const Vector<Value> & values() const { return m_vals;}
-    /*! @brief Values can be changed without influencing the performance cache
+    /*! @brief Change values vector
+     * @note The reason why \c values can be changed directly while \c
+     * row_offsets and \c column_indices cannot,  is that changing the values
+     * does not influence the performance cache, while changing the sparsity
+     * pattern through \c row_offsets and \c column_indices does
      * @return Values array reference
      */
     Vector<Value> & values() { return m_vals;}
 
+    ///@cond
     template<class value_type>
     void symv(SharedVectorTag, SerialTag, value_type alpha, const value_type* RESTRICT x, value_type beta, value_type* RESTRICT y) const
     {
@@ -211,6 +342,7 @@ struct SparseMatrix
             m_vals.size(), row_ptr, col_ptr, val_ptr, alpha, beta, x, y);
     }
 #endif
+    ///@endcond
 
     /**
     * @brief Transposition
@@ -224,7 +356,7 @@ struct SparseMatrix
         // cols are sorted
 
         // We need to sort now
-        SparseMatrix<Index,Value,thrust::host_vector> o;
+        SparseMatrix<Index,Value,Vector> o;
         o.m_num_rows = m_num_cols;
         o.m_num_cols = m_num_rows;
 
@@ -249,7 +381,7 @@ struct SparseMatrix
     //
     // We enable the following only for serial sparse matrices
 
-    /*! @brief two Matrices are considered equal if elements are equal
+    /*! @brief Two Matrices are considered equal if elements and sparsity pattern are equal
      *
      * @param rhs Matrix to be compared to this
      * @return true if rhs does not equal this
@@ -272,7 +404,7 @@ struct SparseMatrix
         return false;
     }
 
-    /*! @brief two Matrices are considered equal if elements are equal
+    /*! @brief Two Matrices are considered equal if elements and sparsity pattern are equal
      *
      * @param rhs Matrix to be compared to this
      * @return true if rhs equals this
@@ -281,20 +413,16 @@ struct SparseMatrix
     std::enable_if_t<dg::has_policy_v<OtherMatrix, SerialTag>, bool> operator==( const SparseMatrix& rhs) const {return !((*this != rhs));}
 
     /**
-     * @brief subtract
+     * @brief Negate
      *
      * @return
      */
-    template<class OtherMatrix = SparseMatrix>
-    enable_if_serial<OtherMatrix> operator-() const
+    SparseMatrix operator-() const
     {
-        SparseMatrix temp(*this);
-        for( unsigned i=0; i<m_vals.size(); i++)
-            temp.m_vals[i] = -m_vals[i];
-        return temp;
+        return (*this)*(Value(-1));
     }
     /**
-     * @brief add
+     * @brief Add
      *
      * @param op
      *
@@ -382,6 +510,7 @@ struct SparseMatrix
     /**
      * @brief scalar multiplication
      *
+     * Simply multiply values array by given value
      * @param value
      * @param rhs
      *
@@ -398,6 +527,7 @@ struct SparseMatrix
     /**
      * @brief scalar multiplication
      *
+     * Simply multiply values array by given value
      * @param lhs
      * @param value
      *
@@ -410,7 +540,7 @@ struct SparseMatrix
     }
 
     /**
-     * @brief matrix multiplication
+     * @brief matrix-matrix multiplication \f$ C = A*B\f$
      *
      * @param lhs
      * @param rhs
@@ -482,23 +612,6 @@ struct SparseMatrix
             os << "\n";
         }
         return os;
-    }
-
-    // Somewhat expensive
-    void sort_indices()
-    {
-        if( m_num_rows != m_row_offsets.size()-1)
-            throw dg::Error( dg::Message( _ping_) << "Error: Row offsets have size "
-                <<m_row_offsets.size()<<" but num_rows is "<<m_num_rows<<"\n");
-        if( m_cols.size() != m_vals.size())
-            throw dg::Error( dg::Message( _ping_) << "Error: Column indices size "
-                <<m_cols.size()<<" not equal to values size "<<m_vals.size()<<"\n");
-
-        // Sort each row
-        Vector<Index> rows = detail::csr2coo( m_row_offsets);
-        Vector<Index> cols = m_cols;
-        Vector<Value> vals = m_vals;
-        setFromCoo( m_num_rows, m_num_cols, rows, cols, vals, true);
     }
 
     private:

--- a/inc/dg/backend/sparsematrix.h
+++ b/inc/dg/backend/sparsematrix.h
@@ -55,6 +55,8 @@ template<class Index = int, class Value = double, template<class> class Vector =
 struct SparseMatrix
 {
     using policy = dg::get_execution_policy<Vector<Value>>;
+    using index_type = Index;
+    using value_type = Value;
     template<class OtherMatrix>
     using enable_if_serial = std::enable_if_t<std::is_same_v<typename OtherMatrix::policy, SerialTag>, OtherMatrix>;
 

--- a/inc/dg/backend/sparsematrix.h
+++ b/inc/dg/backend/sparsematrix.h
@@ -1,0 +1,327 @@
+
+#pragma once
+
+#include "tensor_traits.h"
+#include "exceptions.h"
+#include "config.h"
+
+#include "sparsematrix_cpu.h"
+#if THRUST_DEVICE_SYSTEM==THRUST_DEVICE_SYSTEM_CUDA
+#include "sparsematrix_gpu.cuh"
+#elif THRUST_DEVICE_SYSTEM==THRUST_DEVICE_SYSTEM_OMP
+#include "sparsematrix_omp.h"
+#endif
+
+namespace dg
+{
+
+template<class I>
+I csr2coo( const I& csr)
+{
+    unsigned num_rows = csr.size()-1;
+    I coo( csr[num_rows]);
+    for( unsigned i=0; i<num_rows; i++)
+        for (int jj = csr[i]; jj < csr[i+1]; jj++)
+            coo[jj] = i;
+    return coo;
+}
+//coo must be sorted
+template<class I>
+I coo2csr( unsigned num_rows, const I& coo)
+{
+    I csr(num_rows+1,0);
+    std::inclusive_scan( coo.begin(), coo.end(), csr.begin()+1);
+    return csr;
+}
+
+template<class Index = int, class Value = double, template<class> class Vector = thrust::host_vector>
+struct SparseMatrix
+{
+    SparseMatrix() = default;
+    SparseMatrix( size_t num_rows, size_t num_cols, Vector<Index> row_offsets, Vector<Index> cols, Vector<Value> vals)
+    : m_num_rows( num_rows), m_num_cols( num_cols), m_row_offsets( row_offsets), m_cols(cols), m_vals(vals)
+    {
+    }
+
+    void set( size_t num_rows, size_t num_cols, const Vector<Index>& row_offsets, const Vector<Index> cols, const Vector<Value>& vals)
+    {
+        m_num_rows = num_rows, m_num_cols = num_cols;
+        m_row_offsets = row_offsets, m_cols = cols, m_vals = vals;
+    }
+
+    size_t num_rows() const { return m_num_rows;}
+    size_t num_cols() const { return m_num_cols;}
+    size_t num_vals() const { return m_vals.size();}
+    const Vector<Index> & row_offsets() const { return m_row_offsets;}
+    const Vector<Index> & column_indices() const { return m_cols;}
+    const Vector<Value> & values() const { return m_vals;}
+
+    template<class value_type>
+    void symv(SharedVectorTag, SerialTag, value_type alpha, const value_type* RESTRICT x, value_type beta, value_type* RESTRICT y) const
+    {
+        detail::spmv_cpu_kernel( m_num_rows, m_row_offsets, m_cols, m_vals, alpha, beta, x, y);
+    }
+#if THRUST_DEVICE_SYSTEM==THRUST_DEVICE_SYSTEM_CUDA
+    template<class value_type>
+    void symv(SharedVectorTag, CudaTag, value_type alpha, const value_type* x, value_type beta, value_type* y) const;
+    //{
+    //    detail::spmv_gpu_kernel( m_num_rows, m_row_offsets, m_cols, m_vals, alpha, beta, x, y);
+    //}
+#elif THRUST_DEVICE_SYSTEM==THRUST_DEVICE_SYSTEM_OMP
+    template<class value_type>
+    void symv(SharedVectorTag, OmpTag, value_type alpha, const value_type* x, value_type beta, value_type* y) const;
+    //{
+    //    detail::spmv_omp_kernel( m_num_rows, m_row_offsets, m_cols, m_vals, alpha, beta, x, y);
+    //}
+#endif
+
+    /**
+    * @brief Transposition
+    *
+    * @return  A newly generated SparseMatrix containing the transpose.
+    */
+    SparseMatrix transpose() const
+    {
+        SparseMatrix o(*this);
+        auto coo = csr2coo(o.m_row_offsets);
+        o.m_cols.swap( coo);
+        o.m_row_offsets = coo2csr( o.m_num_cols, coo);
+        return o;
+    }
+
+
+    /*! @brief two Matrices are considered equal if elements are equal
+     *
+     * @param rhs Matrix to be compared to this
+     * @return true if rhs does not equal this
+     */
+    bool operator!=( const SparseMatrix& rhs) const{
+        if( rhs.m_num_rows != m_num_rows)
+            return true;
+        if( rhs.m_num_cols != m_num_cols)
+            return true;
+        for( size_t i = 0; i < m_row_offsets.size(); i++)
+            if( m_row_offsets[i] != rhs.m_row_offsets[i])
+                return true;
+        for( size_t i = 0; i < m_cols.size(); i++)
+            if( m_cols[i] != rhs.m_cols[i])
+                return true;
+        for( size_t i = 0; i < m_vals.size(); i++)
+            if( m_vals[i] != rhs.m_vals[i])
+                return true;
+        return false;
+    }
+
+    /*! @brief two Matrices are considered equal if elements are equal
+     *
+     * @param rhs Matrix to be compared to this
+     * @return true if rhs equals this
+     */
+    bool operator==( const SparseMatrix& rhs) const {return !((*this != rhs));}
+
+    /**
+     * @brief subtract
+     *
+     * @return
+     */
+    SparseMatrix operator-() const
+    {
+        SparseMatrix temp(*this);
+        for( unsigned i=0; i<m_vals.size(); i++)
+            temp.m_vals[i] = -m_vals[i];
+        return temp;
+    }
+    /**
+     * @brief add
+     *
+     * @param op
+     *
+     * @return
+     */
+    SparseMatrix& operator+=( const SparseMatrix& op)
+    {
+        SparseMatrix tmp = *this + op;
+        swap( tmp, *this);
+    }
+    /**
+     * @brief subtract
+     *
+     * @param op
+     *
+     * @return
+     */
+    SparseMatrix& operator-=( const SparseMatrix& op)
+    {
+        SparseMatrix tmp = *this + (-op);
+        swap( tmp, *this);
+    }
+    /**
+     * @brief scalar multiply
+     *
+     * @param value
+     *
+     * @return
+     */
+    SparseMatrix& operator*=( const Value& value )
+    {
+        for( unsigned i=0; i<m_vals.size(); i++)
+            m_vals[i] *= value;
+        return *this;
+    }
+    /**
+     * @brief add
+     *
+     * @param lhs
+     * @param rhs
+     *
+     * @return
+     */
+    friend SparseMatrix operator+( const SparseMatrix& lhs, const SparseMatrix& rhs)
+    {
+        if( lhs.m_num_cols != rhs.m_num_cols)
+            throw dg::Error( dg::Message( _ping_) << "Error: cannot add matrix with "
+                <<lhs.m_num_cols<<" columns to matrix with "<<rhs.m_num_cols<<" columns\n");
+        if( lhs.m_num_rows != rhs.m_num_rows)
+            throw dg::Error( dg::Message( _ping_) << "Error: cannot add matrix with "
+                <<lhs.m_num_rows<<" rows to matrix with "<<rhs.m_num_rows<<" rows\n");
+        Vector<Index> row_offsets, cols;
+        Vector<Value> vals;
+
+        detail::spadd_cpu_kernel( lhs.m_num_rows, lhs.m_num_cols,
+            lhs.m_row_offsets, lhs.m_cols, lhs.m_vals,
+            rhs.m_row_offsets, rhs.m_cols, rhs.m_vals,
+            row_offsets, cols, vals);
+
+        SparseMatrix temp(lhs.m_num_rows, rhs.m_num_cols, row_offsets, cols, vals);
+        return temp;
+    }
+    /**
+     * @brief subtract
+     *
+     * @param lhs
+     * @param rhs
+     *
+     * @return
+     */
+    friend SparseMatrix operator-( const SparseMatrix& lhs, const SparseMatrix& rhs)
+    {
+        SparseMatrix temp(lhs);
+        temp-=rhs;
+        return temp;
+    }
+    /**
+     * @brief scalar multiplication
+     *
+     * @param value
+     * @param rhs
+     *
+     * @return
+     */
+    friend SparseMatrix operator*( const Value& value, const SparseMatrix& rhs )
+    {
+        SparseMatrix temp(rhs);
+        temp*=value;
+        return temp;
+    }
+
+    /**
+     * @brief scalar multiplication
+     *
+     * @param lhs
+     * @param value
+     *
+     * @return
+     */
+    friend SparseMatrix operator*( const SparseMatrix& lhs, const Value& value)
+    {
+        return  value*lhs;
+    }
+
+    /**
+     * @brief matrix multiplication
+     *
+     * @param lhs
+     * @param rhs
+     *
+     * @return
+     */
+    friend SparseMatrix operator*( const SparseMatrix& lhs, const SparseMatrix& rhs)
+    {
+        if( lhs.m_num_cols != rhs.m_num_rows)
+            throw dg::Error( dg::Message( _ping_) << "Error: cannot multiply matrix with "
+                <<lhs.m_num_cols<<" columns with matrix with "<<rhs.m_num_rows<<" rows\n");
+
+        Vector<Index> row_offsets, cols;
+        Vector<Value> vals;
+
+        detail::spgemm_cpu_kernel( lhs.m_num_rows, lhs.m_num_cols,
+            lhs.m_row_offsets, lhs.m_cols, lhs.m_vals,
+            rhs.m_row_offsets, rhs.m_cols, rhs.m_vals,
+            row_offsets, cols, vals);
+
+        SparseMatrix temp(lhs.m_num_rows, rhs.m_num_cols, row_offsets, cols, vals);
+        return temp;
+    }
+
+    /**
+     * @brief matrix-vector multiplication  \f$  y = S x\f$
+     *
+     * @snippet{trimleft} operator_t.cpp matvec
+     * @param S Matrix
+     * @param x Vector
+     *
+     * @return Vector
+     */
+    friend Vector<Value> operator*( const SparseMatrix& S, const Vector<Value>& x)
+    {
+        if( S.m_num_cols != x.size())
+            throw dg::Error( dg::Message( _ping_) << "Error: cannot multiply matrix with "
+                <<S.m_num_cols<<" columns with vector with "<<x.size()<<" rows\n");
+
+        Vector<Value> out(S.m_num_rows);
+        const Value* RESTRICT x_ptr = thrust::raw_pointer_cast( x.data());
+        Value* RESTRICT y_ptr = thrust::raw_pointer_cast( out.data());
+        S.symv( SharedVectorTag(), SerialTag(), Value(1), x_ptr, Value(0), y_ptr);
+        return out;
+    }
+
+    /*! @brief puts a matrix linewise in output stream
+     *
+     * @tparam Ostream The stream e.g. std::cout
+     * @param os the outstream
+     * @param mat the matrix to output
+     * @return the outstream
+     */
+    template< class Ostream>
+    friend Ostream& operator<<(Ostream& os, const SparseMatrix& mat)
+    {
+        os << "Sparse Matrix with "<<mat.m_num_rows<<" rows and "<<mat.m_num_cols<<" columns\n";
+        os << " # non-zeroes "<<mat.m_vals.size()<<"\n";
+        for (int i = 0; i < mat.m_num_rows; i++)
+        {
+            for (int pB = mat.m_row_offsets[i]; pB < mat.m_row_offsets[i+1]; pB++)
+            {
+                os << "("<<i<<","<<mat.m_cols[pB]<<","<<mat.m_vals[pB]<<") ";
+            }
+            os << "\n";
+        }
+        return os;
+    }
+
+    private:
+    size_t m_num_rows, m_num_cols;
+    Vector<Index> m_row_offsets, m_cols;
+    Vector<Value> m_vals;
+};
+
+///@addtogroup traits
+///@{
+template <class I, class T, template<class> class V>
+struct TensorTraits<SparseMatrix<I, T, V> >
+{
+    using value_type  = T;
+    using tensor_category = SparseBlockMatrixTag;
+};
+///@}
+}//namespace dg
+

--- a/inc/dg/backend/sparsematrix_cpu.h
+++ b/inc/dg/backend/sparsematrix_cpu.h
@@ -15,7 +15,7 @@ namespace detail
 
 // A = B*C
 // We do not catch explicit zeros in A
-// Entries in A are sorted
+// Entries in A are sorted (even if B and/or C are not)
 template<class I, class V>
 void spgemm_cpu_kernel(
     size_t B_num_rows, size_t B_num_cols, size_t C_num_cols,

--- a/inc/dg/backend/sparsematrix_cpu.h
+++ b/inc/dg/backend/sparsematrix_cpu.h
@@ -175,39 +175,41 @@ void spadd_cpu_kernel(
     }
 }
 
+struct CSRCache_cpu
+{
+    void forget(){}
+};
 //y = alpha A*x + beta y
 template<class I, class V, class value_type, class C1, class C2>
 void spmv_cpu_kernel(
-    size_t A_num_rows,
-    const I& A_pos , const I& A_idx, const V& A_val,
+    CSRCache_cpu& cache,
+    size_t A_num_rows, size_t A_num_cols, size_t A_nnz,
+    const I* RESTRICT A_pos , const I* RESTRICT A_idx, const V*RESTRICT  A_val,
     value_type alpha, value_type beta, const C1* RESTRICT x_ptr, C2* RESTRICT y_ptr
 )
 {
-    const auto* RESTRICT val_ptr = thrust::raw_pointer_cast( &A_val[0]);
-    const auto* RESTRICT row_ptr = thrust::raw_pointer_cast( &A_pos[0]);
-    const auto* RESTRICT col_ptr = thrust::raw_pointer_cast( &A_idx[0]);
     if( beta == value_type(1))
     {
-//    #pragma omp parallel for
+//    #pragma omp for nowait
         for(int i = 0; i < (int)A_num_rows; i++)
         {
-            for (int jj = row_ptr[i]; jj < row_ptr[i+1]; jj++)
+            for (int jj = A_pos[i]; jj < A_pos[i+1]; jj++)
             {
-                int j = col_ptr[jj];
-                y_ptr[i] = DG_FMA( alpha*val_ptr[jj], x_ptr[j], y_ptr[i]);
+                int j = A_idx[jj];
+                y_ptr[i] = DG_FMA( alpha*A_val[jj], x_ptr[j], y_ptr[i]);
             }
         }
     }
     else
     {
-//    #pragma omp parallel for
+//    #pragma omp for nowait
         for(int i = 0; i < (int)A_num_rows; i++)
         {
             value_type temp = beta*y_ptr[i];
-            for (int jj = row_ptr[i]; jj < row_ptr[i+1]; jj++)
+            for (int jj = A_pos[i]; jj < A_pos[i+1]; jj++)
             {
-                int j = col_ptr[jj];
-                temp = DG_FMA( val_ptr[jj], x_ptr[j], temp);
+                int j = A_idx[jj];
+                temp = DG_FMA( A_val[jj], x_ptr[j], temp);
             }
 
             y_ptr[i] = DG_FMA( alpha, temp, y_ptr[i]);

--- a/inc/dg/backend/sparsematrix_cpu.h
+++ b/inc/dg/backend/sparsematrix_cpu.h
@@ -1,0 +1,222 @@
+#pragma once
+
+#include <vector>
+#include <algorithm>
+#include <numeric>
+
+namespace dg
+{
+namespace detail
+{
+
+
+// MW if ever needed the code for assembly of sparsity structure of A and the computation of A can be separated
+// TODO Make gemm pointers restrict!?
+
+// A = B*C
+// We do not catch explicit zeros in A
+// Entries in A are sorted
+template<class I, class V>
+void spgemm_cpu_kernel(
+    size_t B_num_rows, size_t B_num_cols,
+    const I& B_pos , const I& B_idx, const V& B_val,
+    const I& C_pos , const I& C_idx, const V& C_val,
+          I& A_pos ,       I& A_idx,       V& A_val
+)
+{
+    // We follow
+    // https://commit.csail.mit.edu/papers/2018/kjolstad-18-workspaces.pdf
+    // Sparse data structures do not support fast random inserts ...
+    // That is why a dense workspace is inserted
+    // ... a dense workspace turns sparse-sparse into sparse-dense iterations (fewer conditional checks)
+    // Workspace have easier merge at the cost of managing the workspace and reduced temporal locality
+    //
+    // 1. Figure 10: assemble sparsity structure of A
+    // (Theoretically this could be cached if we did the same multiplication multiple times)
+    A_pos.resize( B_num_rows+1);
+    A_pos[0] = 0;
+    std::vector<bool> w( B_num_cols, false); // A dense work array
+    // A_ij  = B_ik C_kj
+    I wlist; // one row of A
+    for( int i = 0; i<(int)B_num_rows; i++)
+    {
+        for( int pB = B_pos[i]; pB < B_pos[i+1]; pB++)
+        {
+            int k = B_idx[pB];
+            for( int pC = C_pos[k]; pC < C_pos[k+1]; pC++)
+            {
+                int j = C_idx[pC];
+                if( not w[j])
+                {
+                    wlist.push_back( j);
+                    w[j] = true;
+                }
+            }
+        }
+        // Sort entries of A in each row
+        std::sort( wlist.begin(), wlist.end());
+
+        // Append wlist to A_idx
+        A_idx.resize( A_pos[i] + wlist.size());
+        A_pos[i+1] = A_pos[i] + wlist.size();
+        for( int pwlist = 0; pwlist < (int)wlist.size(); pwlist ++)
+        {
+            int j = wlist[pwlist];
+            A_idx[ A_pos[i] + pwlist ] = j;
+            w[j] = false;
+        }
+        wlist.resize( 0);
+    }
+    A_val.resize( A_pos[B_num_rows]);
+    // 2. Figure 1d) Do the actual multiplication
+
+    // A dense workspace array
+    V workspace( B_num_cols, 0);
+    for (int i = 0; i < (int)B_num_rows; i++)
+    {
+        // Dense Workspace array
+        for (int pB = B_pos[i]; pB < B_pos[i+1]; pB++)
+        {
+            int k = B_idx[pB];
+            for (int pC = C_pos[k]; pC < C_pos[k+1]; pC++)
+            {
+                int j = C_idx[pC];
+                workspace[j] += B_val[pB] * C_val[pC];
+            }
+        }
+        // We have to know sparse structure of A...
+        for (int pA = A_pos[i]; pA < A_pos[i+1]; pA++)
+        {
+            int j = A_idx[pA];
+            A_val[pA] = workspace[j];
+            workspace[j] = 0;
+        }
+    }
+}
+
+//A = B + C
+// We do not catch explicit zeros in A
+// Entries in A are sorted
+template<class I, class V>
+void spadd_cpu_kernel(
+    size_t B_num_rows, size_t B_num_cols,
+    const I& B_pos , const I& B_idx, const V& B_val,
+    const I& C_pos , const I& C_idx, const V& C_val,
+          I& A_pos ,       I& A_idx,       V& A_val // restrict !
+)
+{
+    // We follow
+    // https://commit.csail.mit.edu/papers/2018/kjolstad-18-workspaces.pdf
+    //
+    // 1. (No Figure) assemble sparsity structure of A
+    // (Theoretically this could be cached if we did the same multiplication multiple times)
+    A_pos.resize( B_num_rows+1);
+    A_pos[0] = 0;
+    std::vector<bool> w( B_num_cols, false); // A dense work array
+    // A_ij  = B_ik C_kj
+    I wlist; // one row of A
+    for( int i = 0; i<(int)B_num_rows; i++)
+    {
+        // Dense Workspace array
+        for (int pB = B_pos[i]; pB < B_pos[i+1]; pB++)
+        {
+            int ib = B_idx[pB];
+            wlist.push_back(ib);
+            w[ib] = true;
+        }
+        for (int pC = C_pos[i]; pC < C_pos[i+1]; pC++)
+        {
+            int ic = C_idx[pC];
+            if( not w[ic])
+            {
+                wlist.push_back(ic);
+                w[ic] = true;
+            }
+        }
+        // Sort entries of A in each row
+        std::sort( wlist.begin(), wlist.end());
+        // Append wlist to A_idx
+        A_idx.resize( A_pos[i] + wlist.size());
+        A_pos[i+1] = A_pos[i] + wlist.size();
+        for( int pwlist = 0; pwlist < (int)wlist.size(); pwlist ++)
+        {
+            int j = wlist[pwlist];
+            A_idx[ A_pos[i] + pwlist ] = j;
+            w[j] = false;
+        }
+        wlist.resize( 0);
+    }
+    A_val.resize( A_pos[B_num_rows]);
+    //
+    // 2. Figure 6) Sparse vector addition
+
+    // A dense workspace array
+    V workspace( B_num_cols, 0);
+    for (int i = 0; i < (int)B_num_rows; i++)
+    {
+        // Dense Workspace array
+        for (int pB = B_pos[i]; pB < B_pos[i+1]; pB++)
+        {
+            int ib = B_idx[pB];
+            workspace[ib] = B_val[pB];
+        }
+        for (int pC = C_pos[i]; pC < C_pos[i+1]; pC++)
+        {
+            int ic = C_idx[pC];
+            workspace[ic] += C_val[pC];
+        }
+        // We have to know sparse structure of A...
+        for (int pA = A_pos[i]; pA < A_pos[i+1]; pA++)
+        {
+            int ia = A_idx[pA];
+            A_val[pA] = workspace[ia];
+            workspace[ia] = 0;
+        }
+    }
+}
+
+//y = alpha A*x + beta y
+template<class I, class V, class value_type, class C1, class C2>
+void spmv_cpu_kernel(
+    size_t A_num_rows,
+    const I& A_pos , const I& A_idx, const V& A_val,
+    value_type alpha, value_type beta, const C1* RESTRICT x_ptr, C2* RESTRICT y_ptr
+)
+{
+    const auto* RESTRICT val_ptr = thrust::raw_pointer_cast( &A_val[0]);
+    const auto* RESTRICT row_ptr = thrust::raw_pointer_cast( &A_pos[0]);
+    const auto* RESTRICT col_ptr = thrust::raw_pointer_cast( &A_idx[0]);
+    if( beta == value_type(1))
+    {
+//    #pragma omp parallel for
+        for(int i = 0; i < (int)A_num_rows; i++)
+        {
+            for (int jj = row_ptr[i]; jj < row_ptr[i+1]; jj++)
+            {
+                int j = col_ptr[jj];
+                y_ptr[i] = DG_FMA( alpha*val_ptr[jj], x_ptr[j], y_ptr[i]);
+            }
+        }
+    }
+    else
+    {
+//    #pragma omp parallel for
+        for(int i = 0; i < (int)A_num_rows; i++)
+        {
+            value_type temp = beta*y_ptr[i];
+            for (int jj = row_ptr[i]; jj < row_ptr[i+1]; jj++)
+            {
+                int j = col_ptr[jj];
+                temp = DG_FMA( val_ptr[jj], x_ptr[j], temp);
+            }
+
+            y_ptr[i] = DG_FMA( alpha, temp, y_ptr[i]);
+        }
+    }
+}
+
+
+
+}// namespace detail
+
+} // namespace dg

--- a/inc/dg/backend/sparsematrix_gpu.cuh
+++ b/inc/dg/backend/sparsematrix_gpu.cuh
@@ -1,0 +1,8 @@
+#pragma once
+namespace dg
+{
+namespace detail
+{
+
+} // namespace detail
+} // namespace dg

--- a/inc/dg/backend/sparsematrix_gpu.cuh
+++ b/inc/dg/backend/sparsematrix_gpu.cuh
@@ -1,8 +1,208 @@
 #pragma once
+
+#include <cusparse.h>
+#include <exception>
+#include <complex.h>
+#include <thrust/complex.h>
+
 namespace dg
 {
 namespace detail
 {
+template<class value_type>
+inline cudaDataType_t getCudaDataType(){ assert( false && "CUDA Type not supported!\n" ); return CUDA_R_64F; }
+
+template<> inline cudaDataType_t getCudaDataType<int>(){ return CUDA_R_32I;}
+template<> inline cudaDataType_t getCudaDataType<float>() { return CUDA_R_32F;}
+template<> inline cudaDataType_t getCudaDataType<double>(){ return CUDA_R_64F;}
+template<> inline cudaDataType_t getCudaDataType<std::complex<float>>(){ return CUDA_C_32F;}
+template<> inline cudaDataType_t getCudaDataType<std::complex<double>>(){ return CUDA_C_64F;}
+template<> inline cudaDataType_t getCudaDataType<thrust::complex<float>>(){ return CUDA_C_32F;}
+template<> inline cudaDataType_t getCudaDataType<thrust::complex<double>>(){ return CUDA_C_64F;}
+
+template<class value_type>
+inline cusparseIndexType_t getCudaIndexType(){ assert( false && "CUDA Type not supported!\n" ); return CUSPARSE_INDEX_32I; }
+template<> inline cusparseIndexType_t getCudaIndexType<int>(){ return CUSPARSE_INDEX_32I;}
+template<> inline cusparseIndexType_t getCudaIndexType<signed long int>(){ return CUSPARSE_INDEX_64I;}
+
+
+struct CusparseError : public std::exception
+{
+    CusparseError( cusparseStatus_t error): m_error( error) {}
+
+    cusparseStatus_t error() const { return m_error;}
+    cusparseStatus_t& error() { return m_error;}
+    char const* what() const noexcept{
+        return cusparseGetErrorString(m_error);}
+  private:
+    cusparseStatus_t m_error;
+};
+
+struct CusparseErrorHandle
+{
+    CusparseErrorHandle operator=( cusparseStatus_t err)
+    {
+        CusparseErrorHandle h;
+        return h(err);
+    }
+    CusparseErrorHandle operator()( cusparseStatus_t err)
+    {
+        if( err != CUSPARSE_STATUS_SUCCESS)
+            throw CusparseError( err);
+        return *this;
+    }
+};
+
+
+// Singleton
+// https://stackoverflow.com/questions/1008019/how-do-you-implement-the-singleton-design-pattern
+struct CusparseHandle
+{
+    static CusparseHandle& getInstance()
+    {
+        // Exists only once even in different translation units
+        // https://stackoverflow.com/questions/50609921/singleton-translation-unit-confusion
+        static CusparseHandle instance;
+        return instance;
+    }
+    private:
+    cusparseHandle_t m_handle;
+    CusparseHandle()
+    {
+        cusparseCreate( &m_handle);
+    }
+    ~CusparseHandle()
+    {
+        cusparseDestroy(m_handle);
+    }
+    public:
+    cusparseHandle_t handle() const { return m_handle;}
+    CusparseHandle( const CusparseHandle&) = delete;
+    void operator=( const CusparseHandle&) = delete;
+};
+
+
+inline bool cusparse_is_initialized = false;
+
+// https://docs.nvidia.com/cuda/cusparse/#cusparsespmv
+struct CusparseCSRCache
+{
+    CusparseCSRCache() = default;
+    template<class I, class V>
+    CusparseCSRCache(
+        size_t num_rows, size_t num_cols, size_t nnz,
+        const I* pos , const I* idx, const V* val)
+    {
+        update( num_rows, num_cols, nnz, pos, idx, val);
+    }
+    CusparseCSRCache( const CusparseCSRCache& src)
+    {
+        // Copying makes the cache inactive
+    }
+    CusparseCSRCache( CusparseCSRCache&& src)
+    {
+        src.swap(*this);
+    }
+    CusparseCSRCache& operator=( const CusparseCSRCache& src){
+        if( &src != this)
+        {
+            CusparseCSRCache tmp(src);
+            tmp.swap( *this);
+        }
+        return *this;
+    }
+    CusparseCSRCache& operator=( CusparseCSRCache&& src){
+        CusparseCSRCache tmp( std::move(src));
+        tmp.swap(*this);
+        return *this;
+    }
+    ~CusparseCSRCache( )
+    {
+        if ( m_dBuffer != nullptr)
+            cudaFree( m_dBuffer);
+        if( m_active)
+            cusparseDestroySpMat( m_matA);
+    }
+    void swap( CusparseCSRCache& src)
+    {
+        std::swap( m_active, src.m_active);
+        std::swap( m_matA, src.m_matA);
+        std::swap( m_dBuffer, src.m_dBuffer);
+        std::swap( m_bufferSize, src.m_bufferSize);
+    }
+    bool isUpToDate() const { return m_active;}
+    template<class I, class V>
+    void update(
+        size_t num_rows, size_t num_cols, size_t nnz,
+        const I* pos , const I* idx, const V* val)
+    {
+        // cusparse practically only supports uniform data-types (e.g. double Matrix, complex vector is not supported)
+        CusparseErrorHandle err;
+        cusparseConstDnVecDescr_t vecX;
+        cusparseDnVecDescr_t vecY;
+        err = cusparseCreateConstCsr( &m_matA, num_rows, num_cols, nnz,
+            pos, idx, val, getCudaIndexType<I>(), getCudaIndexType<I>(),
+            CUSPARSE_INDEX_BASE_ZERO, getCudaDataType<V>() );
+        V * x_ptr;
+        cudaMalloc( &x_ptr, num_cols*sizeof(V));
+        err = cusparseCreateConstDnVec( &vecX, num_cols, x_ptr, getCudaDataType<V>());
+        V * y_ptr;
+        cudaMalloc( &y_ptr, num_cols*sizeof(V));
+        err = cusparseCreateDnVec( &vecY, num_rows, y_ptr, getCudaDataType<V>());
+        size_t bufferSize = 0;
+        V alpha = 1, beta = 0;
+        //ALG1 is not reproducible, ALG2 is bitwise reproducible
+        err = cusparseSpMV_bufferSize( CusparseHandle::getInstance().handle(),
+            CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha, m_matA, vecX, &beta, vecY,
+            getCudaDataType<V>(), CUSPARSE_SPMV_CSR_ALG1, &bufferSize);
+        cudaMalloc( &m_dBuffer, bufferSize);
+        m_active = true;
+        err = cusparseSpMV_preprocess( CusparseHandle::getInstance().handle(),
+            CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha, m_matA, vecX, &beta, vecY,
+            getCudaDataType<V>(), CUSPARSE_SPMV_CSR_ALG1, m_dBuffer);
+        // m_buffer is now associated to m_matA
+        err = cusparseDestroyDnVec( vecX);
+        err = cusparseDestroyDnVec( vecY);
+        cudaFree( x_ptr);
+        cudaFree( y_ptr);
+    }
+    size_t getBufferSize() { return m_bufferSize;}
+    void * getBuffer() { return m_dBuffer;}
+    cusparseConstSpMatDescr_t getSpMat() const { return m_matA;}
+
+    private:
+    bool m_active = false;
+    cusparseConstSpMatDescr_t m_matA;
+    void * m_dBuffer = nullptr;
+    size_t m_bufferSize = 0;
+};
+
+//y = alpha A*x + beta y
+template<class I, class V, class value_type, class C1, class C2>
+void spmv_gpu_kernel(
+    CusparseCSRCache& cache,
+    size_t A_num_rows, size_t A_num_cols, size_t A_nnz,
+    const I* A_pos , const I* A_idx, const V* A_val,
+    value_type alpha, value_type beta, const C1* x_ptr, C2* y_ptr
+)
+{
+    CusparseErrorHandle err;
+    // Assume here that the descriptors are lightweight structures ...
+    cusparseConstDnVecDescr_t vecX;
+    cusparseDnVecDescr_t vecY;
+    err = cusparseCreateConstDnVec( &vecX, A_num_cols, x_ptr, getCudaDataType<C1>());
+    err = cusparseCreateDnVec( &vecY, A_num_rows, y_ptr, getCudaDataType<C2>());
+
+    if( not cache.isUpToDate())
+        cache.update<I,V>( A_num_rows, A_num_cols, A_nnz, A_pos, A_idx, A_val);
+
+    err = cusparseSpMV( CusparseHandle::getInstance().handle(), CUSPARSE_OPERATION_NON_TRANSPOSE,
+            &alpha, cache.getSpMat(), vecX, &beta, vecY, getCudaDataType<V>(),
+            CUSPARSE_SPMV_CSR_ALG1, cache.getBuffer());
+
+    err = cusparseDestroyDnVec( vecX);
+    err = cusparseDestroyDnVec( vecY);
+}
 
 } // namespace detail
 } // namespace dg

--- a/inc/dg/backend/sparsematrix_omp.h
+++ b/inc/dg/backend/sparsematrix_omp.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/inc/dg/backend/sparsematrix_omp.h
+++ b/inc/dg/backend/sparsematrix_omp.h
@@ -1,1 +1,50 @@
 #pragma once
+namespace dg
+{
+namespace detail
+{
+// !!! Do not edit by hand:
+// 1. copy spmv_cpu_kernel from sparsematrix_cpu.h
+// 2. uncomment the pragma omp parallel
+// 3. Rename cpu to omp
+//y = alpha A*x + beta y
+template<class I, class V, class value_type, class C1, class C2>
+void spmv_omp_kernel(
+    size_t A_num_rows,
+    const I& A_pos , const I& A_idx, const V& A_val,
+    value_type alpha, value_type beta, const C1* RESTRICT x_ptr, C2* RESTRICT y_ptr
+)
+{
+    const auto* RESTRICT val_ptr = thrust::raw_pointer_cast( &A_val[0]);
+    const auto* RESTRICT row_ptr = thrust::raw_pointer_cast( &A_pos[0]);
+    const auto* RESTRICT col_ptr = thrust::raw_pointer_cast( &A_idx[0]);
+    if( beta == value_type(1))
+    {
+    #pragma omp parallel for
+        for(int i = 0; i < (int)A_num_rows; i++)
+        {
+            for (int jj = row_ptr[i]; jj < row_ptr[i+1]; jj++)
+            {
+                int j = col_ptr[jj];
+                y_ptr[i] = DG_FMA( alpha*val_ptr[jj], x_ptr[j], y_ptr[i]);
+            }
+        }
+    }
+    else
+    {
+    #pragma omp parallel for
+        for(int i = 0; i < (int)A_num_rows; i++)
+        {
+            value_type temp = beta*y_ptr[i];
+            for (int jj = row_ptr[i]; jj < row_ptr[i+1]; jj++)
+            {
+                int j = col_ptr[jj];
+                temp = DG_FMA( val_ptr[jj], x_ptr[j], temp);
+            }
+
+            y_ptr[i] = DG_FMA( alpha, temp, y_ptr[i]);
+        }
+    }
+}
+}//namespace detail
+}//namespace dg

--- a/inc/dg/backend/sparsematrix_omp.h
+++ b/inc/dg/backend/sparsematrix_omp.h
@@ -4,47 +4,52 @@ namespace dg
 namespace detail
 {
 // !!! Do not edit by hand:
-// 1. copy spmv_cpu_kernel from sparsematrix_cpu.h
+// 1. copy CSRCache_cpu and spmv_cpu_kernel from sparsematrix_cpu.h
 // 2. uncomment the pragma omp parallel
 // 3. Rename cpu to omp
 //y = alpha A*x + beta y
+
+struct CSRCache_omp
+{
+    void forget(){}
+};
+//y = alpha A*x + beta y
 template<class I, class V, class value_type, class C1, class C2>
 void spmv_omp_kernel(
-    size_t A_num_rows,
-    const I& A_pos , const I& A_idx, const V& A_val,
+    CSRCache_omp& cache,
+    size_t A_num_rows, size_t A_num_cols, size_t A_nnz,
+    const I* RESTRICT A_pos , const I* RESTRICT A_idx, const V*RESTRICT  A_val,
     value_type alpha, value_type beta, const C1* RESTRICT x_ptr, C2* RESTRICT y_ptr
 )
 {
-    const auto* RESTRICT val_ptr = thrust::raw_pointer_cast( &A_val[0]);
-    const auto* RESTRICT row_ptr = thrust::raw_pointer_cast( &A_pos[0]);
-    const auto* RESTRICT col_ptr = thrust::raw_pointer_cast( &A_idx[0]);
     if( beta == value_type(1))
     {
-    #pragma omp parallel for
+    #pragma omp for nowait
         for(int i = 0; i < (int)A_num_rows; i++)
         {
-            for (int jj = row_ptr[i]; jj < row_ptr[i+1]; jj++)
+            for (int jj = A_pos[i]; jj < A_pos[i+1]; jj++)
             {
-                int j = col_ptr[jj];
-                y_ptr[i] = DG_FMA( alpha*val_ptr[jj], x_ptr[j], y_ptr[i]);
+                int j = A_idx[jj];
+                y_ptr[i] = DG_FMA( alpha*A_val[jj], x_ptr[j], y_ptr[i]);
             }
         }
     }
     else
     {
-    #pragma omp parallel for
+    #pragma omp for nowait
         for(int i = 0; i < (int)A_num_rows; i++)
         {
             value_type temp = beta*y_ptr[i];
-            for (int jj = row_ptr[i]; jj < row_ptr[i+1]; jj++)
+            for (int jj = A_pos[i]; jj < A_pos[i+1]; jj++)
             {
-                int j = col_ptr[jj];
-                temp = DG_FMA( val_ptr[jj], x_ptr[j], temp);
+                int j = A_idx[jj];
+                temp = DG_FMA( A_val[jj], x_ptr[j], temp);
             }
 
             y_ptr[i] = DG_FMA( alpha, temp, y_ptr[i]);
         }
     }
 }
+
 }//namespace detail
 }//namespace dg

--- a/inc/dg/backend/sparsematrix_omp.h
+++ b/inc/dg/backend/sparsematrix_omp.h
@@ -7,7 +7,6 @@ namespace detail
 // 1. copy CSRCache_cpu and spmv_cpu_kernel from sparsematrix_cpu.h
 // 2. uncomment the pragma omp parallel
 // 3. Rename cpu to omp
-//y = alpha A*x + beta y
 
 struct CSRCache_omp
 {
@@ -18,7 +17,7 @@ template<class I, class V, class value_type, class C1, class C2>
 void spmv_omp_kernel(
     CSRCache_omp& cache,
     size_t A_num_rows, size_t A_num_cols, size_t A_nnz,
-    const I* RESTRICT A_pos , const I* RESTRICT A_idx, const V*RESTRICT  A_val,
+    const I* RESTRICT A_pos , const I* RESTRICT A_idx, const V* RESTRICT  A_val,
     value_type alpha, value_type beta, const C1* RESTRICT x_ptr, C2* RESTRICT y_ptr
 )
 {
@@ -39,14 +38,14 @@ void spmv_omp_kernel(
     #pragma omp for nowait
         for(int i = 0; i < (int)A_num_rows; i++)
         {
-            value_type temp = beta*y_ptr[i];
+            value_type temp = 0;
             for (int jj = A_pos[i]; jj < A_pos[i+1]; jj++)
             {
                 int j = A_idx[jj];
-                temp = DG_FMA( A_val[jj], x_ptr[j], temp);
+                temp = DG_FMA( alpha*A_val[jj], x_ptr[j], temp);
             }
 
-            y_ptr[i] = DG_FMA( alpha, temp, y_ptr[i]);
+            y_ptr[i] = DG_FMA( beta, y_ptr[i], temp);
         }
     }
 }

--- a/inc/dg/backend/sparsematrix_t.cpp
+++ b/inc/dg/backend/sparsematrix_t.cpp
@@ -1,0 +1,105 @@
+
+#include <iostream>
+#include "sparsematrix.h"
+#include "catch2/catch_all.hpp"
+
+TEST_CASE( "Construct sparse matrix")
+{
+    size_t num_rows = 3, num_cols = 5, num_nnz = 6;
+    thrust::host_vector<int> rows(num_rows+1), cols(num_nnz);
+    thrust::host_vector<double> vals(num_nnz);
+    SECTION( "Construct")
+    {
+        dg::SparseMatrix<int,double,thrust::host_vector> mat ( num_rows, num_cols, rows, cols, vals);
+        CHECK( mat.num_rows() == num_rows);
+        CHECK( mat.num_cols() == num_cols);
+        CHECK( mat.num_vals() == vals.size());
+    }
+    SECTION( "Set")
+    {
+        dg::SparseMatrix mat;
+        mat.set( num_rows, num_cols, rows, cols, vals);
+        CHECK( mat.num_rows() == num_rows);
+        CHECK( mat.num_cols() == num_cols);
+        CHECK( mat.num_vals() == vals.size());
+    }
+
+}
+TEST_CASE( "Linear algebra")
+{
+    // 1 0 0 2 3
+    // 2 0 5 0 0
+    // 0 4 0 0 1
+    unsigned num_rows = 3, num_cols = 5;
+    std::vector<int> rows = {0,3,5,7}, cols = {0,3,4,0,2,1,4};
+    std::vector<double> vals = {1,2,3,2,5,4,1};
+    dg::SparseMatrix<int,double,std::vector> A ( num_rows, num_cols, rows, cols, vals);
+
+    // 2 0 0 0
+    // 0 3 3 5
+    // 0 0 4 0
+    // 0 0 0 5
+    // 1 0 0 2
+    num_rows = 5, num_cols = 4;
+    rows = {0,1,4,5,6,8};
+    cols = {0,1,2,3,2,3,0,3};
+    vals = {2,3,3,5,4,5,1,2};
+    dg::SparseMatrix<int,double,std::vector> B ( num_rows, num_cols, rows, cols, vals);
+
+    SECTION( "gemv")
+    {
+        std::vector<double> v(5,2), w(3,0);
+        for( unsigned i=0; i<v.size(); i++)
+            v[i] = double(i+1);
+
+        w = A*v;
+        CHECK( w[0] == 24);
+        CHECK( w[1] == 17);
+        CHECK( w[2] == 13);
+    }
+    SECTION( "gemm")
+    {
+        // 5 0 0 16
+        // 4 0 20 0
+        // 1 12 12 22
+        auto C = A*B;
+        CHECK( C.num_rows() == 3);
+        CHECK( C.num_cols() == 4);
+        CHECK( C.row_offsets() == std::vector<int>{ 0,2,4,8});
+        CHECK( C.column_indices() == std::vector<int>{ 0,3,0,2, 0,1,2,3});
+        CHECK( C.values() == std::vector<double>{ 5,16,4,20,1,12,12,22});
+    }
+    SECTION( "Addition")
+    {
+        // 0 2 0 0 4
+        // 0 1 2 0 0
+        // 0 0 0 0 0
+        num_rows = 3, num_cols = 5;
+        rows = {0,2,4,4}, cols = {1,4,1,2};
+        vals = {2,4,1,2};
+        dg::SparseMatrix<int,double,std::vector> D ( num_rows, num_cols, rows, cols, vals);
+
+        // 1 2 0 2 7
+        // 2 1 7 0 0
+        // 0 4 0 0 1
+        auto C = A + D;
+        CHECK( C.num_rows() == 3);
+        CHECK( C.num_cols() == 5);
+        CHECK( C.row_offsets() == std::vector<int>{ 0,4,7,9});
+        CHECK( C.column_indices() == std::vector<int>{ 0,1,3,4,0,1,2,1,4});
+        CHECK( C.values() == std::vector<double>{ 1,2,2,7,2,1,7,4,1});
+    }
+    SECTION( "Scal")
+    {
+
+        // 0.5 0 0 1 1.5
+        // 1 0 2.5 0 0
+        // 0 2 0 0 0.5
+        auto C = 0.5*A;
+        CHECK( C.num_rows() == 3);
+        CHECK( C.num_cols() == 5);
+        CHECK( C.row_offsets() == std::vector<int>{ 0,3,5,7});
+        CHECK( C.column_indices() == std::vector<int>{ 0,3,4,0,2,1,4});
+        CHECK( C.values() == std::vector<double>{ 0.5,1,1.5,1,2.5,2,0.5});
+    }
+}

--- a/inc/dg/backend/sparsematrix_t.cpp
+++ b/inc/dg/backend/sparsematrix_t.cpp
@@ -7,6 +7,16 @@
 #include "sparsematrix.h"
 #include "catch2/catch_all.hpp"
 
+TEST_CASE("Format conversion")
+{
+    std::vector<int> coo_row = { 0 , 0, 1,1,1, 3, 4,4};
+    std::vector<int> csr_row = dg::coo2csr( 5, coo_row);
+    CHECK( csr_row == std::vector{ 0, 2, 5, 5, 6, 8});
+    auto coo = dg::csr2coo( csr_row );
+    CHECK( coo == coo_row);
+
+
+}
 TEST_CASE( "Construct sparse matrix")
 {
     size_t num_rows = 3, num_cols = 5, num_nnz = 6;
@@ -26,6 +36,19 @@ TEST_CASE( "Construct sparse matrix")
         CHECK( mat.num_rows() == num_rows);
         CHECK( mat.num_cols() == num_cols);
         CHECK( mat.num_vals() == vals.size());
+    }
+    SECTION( "Constructing sorts columns")
+    {
+        // 1 0 0 2 3
+        // 2 0 5 0 0
+        // 0 4 0 0 1
+        unsigned num_rows = 3, num_cols = 5;
+        std::vector<int> rows = {0,3,5,7}, cols = {4,3,0,2,0,4,1};
+        std::vector<double> vals = {3,2,1,5,2,1,4};
+        dg::SparseMatrix<int,double,std::vector> A ( num_rows, num_cols, rows, cols, vals);
+        CHECK( A.row_offsets() == std::vector{0,3,5,7});
+        CHECK( A.column_indices() == std::vector{0,3,4,0,2,1,4});
+        CHECK( A.values() == std::vector<double>{1,2,3,2,5,4,1});
     }
 
 }

--- a/inc/dg/backend/sparsematrix_t.cpp
+++ b/inc/dg/backend/sparsematrix_t.cpp
@@ -5,6 +5,8 @@
 #include "tensor_traits_std.h"
 #include "tensor_traits_thrust.h"
 #include "sparsematrix.h"
+#include "../blas1.h"
+#include "../blas2.h"
 #include "catch2/catch_all.hpp"
 
 TEST_CASE("Format conversion")
@@ -55,6 +57,7 @@ TEST_CASE( "Construct sparse matrix")
     }
     SECTION( "setFromCoo")
     {
+        //![setFromCoo]
         // 1 0 0 2 3
         // 2 0 5 0 0
         // 0 4 0 0 1
@@ -66,11 +69,13 @@ TEST_CASE( "Construct sparse matrix")
         CHECK( A.row_offsets() == std::vector{0,3,5,7});
         CHECK( A.column_indices() == std::vector{0,3,4,0,2,1,4});
         CHECK( A.values() == std::vector<double>{1,2,3,2,5,4,1});
+        //![setFromCoo]
     }
 
 }
 TEST_CASE( "Linear algebra")
 {
+    //![csr_ctor]
     // 1 0 0 2 3
     // 2 0 5 0 0
     // 0 4 0 0 1
@@ -78,6 +83,14 @@ TEST_CASE( "Linear algebra")
     std::vector<int> rows = {0,3,5,7}, cols = {0,3,4,0,2,1,4};
     std::vector<double> vals = {1,2,3,2,5,4,1};
     dg::SparseMatrix<int,double,std::vector> A ( num_rows, num_cols, rows, cols, vals);
+    //
+    CHECK( A.num_rows() == num_rows);
+    CHECK( A.num_cols() == num_cols);
+    CHECK( A.num_vals() == vals.size());
+    CHECK( A.row_offsets()    == rows);
+    CHECK( A.column_indices() == cols);
+    CHECK( A.values()         == vals);
+    //![csr_ctor]
 
     // 2 0 0 0
     // 0 3 3 5
@@ -144,13 +157,16 @@ TEST_CASE( "Linear algebra")
     }
     SECTION( "Addition")
     {
+        //![set]
         // 0 2 0 0 4
         // 0 1 2 0 0
         // 0 0 0 0 0
         num_rows = 3, num_cols = 5;
         rows = {0,2,4,4}, cols = {1,4,1,2};
         vals = {2,4,1,2};
-        dg::SparseMatrix<int,double,std::vector> D ( num_rows, num_cols, rows, cols, vals);
+        dg::SparseMatrix<int,double,std::vector> D;
+        D.set( num_rows, num_cols, rows, cols, vals);
+        //![set]
 
         // 1 2 0 2 7
         // 2 1 7 0 0
@@ -168,25 +184,28 @@ TEST_CASE( "Linear algebra")
         // 0.5 0 0 1 1.5
         // 1 0 2.5 0 0
         // 0 2 0 0 0.5
-        auto C = 0.5*A;
+        auto C = -A;
+        C = 0.5*C;
         CHECK( C.num_rows() == 3);
         CHECK( C.num_cols() == 5);
         CHECK( C.row_offsets() == std::vector<int>{ 0,3,5,7});
         CHECK( C.column_indices() == std::vector<int>{ 0,3,4,0,2,1,4});
-        CHECK( C.values() == std::vector<double>{ 0.5,1,1.5,1,2.5,2,0.5});
+        CHECK( C.values() == std::vector<double>{ -0.5,-1,-1.5,-1,-2.5,-2,-0.5});
     }
 }
 TEST_CASE( "SpMV on device")
 {
+    //![host2device]
     // 1 0 0 2 3
     // 2 0 5 0 0
     // 0 4 0 0 1
     unsigned num_rows = 3, num_cols = 5;
-    // UNSORTED!!
+    // unsorted!!
     std::vector<int> rows = {0,3,5,7}, cols = {0,4,3,0,2,1,4};
     std::vector<double> vals = {1,3,2,2,5,4,1};
     dg::SparseMatrix<int,double,thrust::host_vector> A ( num_rows, num_cols, rows, cols, vals);
     dg::SparseMatrix<int,double, thrust::device_vector> dA( A);
+    //![host2device]
     SECTION( "transpose")
     {
         // 1 2 0
@@ -214,4 +233,52 @@ TEST_CASE( "SpMV on device")
         CHECK( w[1] == 17);
         CHECK( w[2] == 13);
     }
+}
+
+TEST_CASE("Documentation")
+{
+    //![summary]
+    // 1 0 0 2
+    // 2 0 5 0
+    // 0 4 0 0
+    // 0 1 1 0
+    unsigned num_rows = 4, num_cols = 4;
+    std::vector<int> rows = {0,2,4,5,7}, cols = {0,3,0,2,1,1,2};
+    std::vector<double> vals = {1,2,2,5,4,1,1};
+    dg::SparseMatrix<int,double,std::vector> A ( num_rows, num_cols, rows, cols, vals);
+    //
+    // 2 0 0 0
+    // 0 3 3 5
+    // 0 0 4 0
+    // 0 0 0 5
+    // 1 0 0 2
+    num_rows = 5, num_cols = 4;
+    rows = {0,1,4,5,6,8};
+    cols = {0,1,2,3,2,3,0,3};
+    vals = {2,3,3,5,4,5,1,2};
+    dg::SparseMatrix<int,double,std::vector> B ( num_rows, num_cols, rows, cols, vals);
+    //
+    // 3 4 0 0
+    // 10 16.5 13.5 8.5
+    // 0 20 2 4
+    // 10 0 0 2.5
+    // 5.5 2 0 1
+    auto C = B*A.transpose()+0.5*B;
+    //
+    CHECK( C.num_rows() == 5);
+    CHECK( C.num_cols() == 4);
+    CHECK( C.row_offsets() == std::vector<int>{ 0,2,6,9,11,14});
+    CHECK( C.column_indices() == std::vector<int>{ 0,1,0,1,2,3,1,2,3,0,3,0,1,3});
+    CHECK( C.values() == std::vector<double>{ 3, 4, 10, 16.5, 13.5, 8.5, 20, 2, 4, 10, 2.5, 5.5, 2, 1});
+    //
+    // Matrix-vector multiplication can be done on device
+    dg::SparseMatrix<int,double,thrust::device_vector> dC = C;
+    std::vector<double>  v = { 2,4,6,8}, w = {1,2,3,4,5};
+    thrust::device_vector<double> dv( v.begin(), v.end()), dw( w.begin(), w.end());
+    // dw = dC * dv + 0.5 dw
+    dg::blas2::gemv( 1., dC, dv, 0.5, dw);
+    //
+    thrust::copy( dw.begin(), dw.end(), w.begin());
+    CHECK( w == std::vector{22.5,236.,125.5,42.,29.5});
+    //![summary]
 }

--- a/inc/dg/backend/sparsematrix_t.cpp
+++ b/inc/dg/backend/sparsematrix_t.cpp
@@ -10,9 +10,9 @@
 TEST_CASE("Format conversion")
 {
     std::vector<int> coo_row = { 0 , 0, 1,1,1, 3, 4,4};
-    std::vector<int> csr_row = dg::coo2csr( 5, coo_row);
+    std::vector<int> csr_row = dg::detail::coo2csr( 5, coo_row);
     CHECK( csr_row == std::vector{ 0, 2, 5, 5, 6, 8});
-    auto coo = dg::csr2coo( csr_row );
+    auto coo = dg::detail::csr2coo( csr_row );
     CHECK( coo == coo_row);
 
 
@@ -46,6 +46,20 @@ TEST_CASE( "Construct sparse matrix")
         std::vector<int> rows = {0,3,5,7}, cols = {4,3,0,2,0,4,1};
         std::vector<double> vals = {3,2,1,5,2,1,4};
         dg::SparseMatrix<int,double,std::vector> A ( num_rows, num_cols, rows, cols, vals);
+        CHECK( A.row_offsets() == std::vector{0,3,5,7});
+        CHECK( A.column_indices() == std::vector{0,3,4,0,2,1,4});
+        CHECK( A.values() == std::vector<double>{1,2,3,2,5,4,1});
+    }
+    SECTION( "setFromCoo")
+    {
+        // 1 0 0 2 3
+        // 2 0 5 0 0
+        // 0 4 0 0 1
+        unsigned num_rows = 3, num_cols = 5;
+        std::vector<int> rows = {2,2,0,0,0,1,1}, cols = {4,1,4,3,0,2,0};
+        std::vector<double> vals = {1,4, 3,2,1,5,2};
+        dg::SparseMatrix<int,double,std::vector> A;
+        A.setFromCoo( num_rows, num_cols, rows, cols, vals);
         CHECK( A.row_offsets() == std::vector{0,3,5,7});
         CHECK( A.column_indices() == std::vector{0,3,4,0,2,1,4});
         CHECK( A.values() == std::vector<double>{1,2,3,2,5,4,1});

--- a/inc/dg/backend/sparsematrix_t.cpp
+++ b/inc/dg/backend/sparsematrix_t.cpp
@@ -9,6 +9,7 @@
 #include "../blas2.h"
 #include "catch2/catch_all.hpp"
 
+// MW Possible update: With the newest thrust version std::vector can be replaced by thrust::host_vector everywhere
 TEST_CASE("Format conversion")
 {
     std::vector<int> coo_row = { 0 , 0, 1,1,1, 3, 4,4};

--- a/inc/dg/backend/sparsematrix_t.cpp
+++ b/inc/dg/backend/sparsematrix_t.cpp
@@ -48,6 +48,7 @@ TEST_CASE( "Construct sparse matrix")
         std::vector<int> rows = {0,3,5,7}, cols = {4,3,0,2,0,4,1};
         std::vector<double> vals = {3,2,1,5,2,1,4};
         dg::SparseMatrix<int,double,std::vector> A ( num_rows, num_cols, rows, cols, vals);
+        A.sort_indices();
         CHECK( A.row_offsets() == std::vector{0,3,5,7});
         CHECK( A.column_indices() == std::vector{0,3,4,0,2,1,4});
         CHECK( A.values() == std::vector<double>{1,2,3,2,5,4,1});
@@ -61,7 +62,7 @@ TEST_CASE( "Construct sparse matrix")
         std::vector<int> rows = {2,2,0,0,0,1,1}, cols = {4,1,4,3,0,2,0};
         std::vector<double> vals = {1,4, 3,2,1,5,2};
         dg::SparseMatrix<int,double,std::vector> A;
-        A.setFromCoo( num_rows, num_cols, rows, cols, vals);
+        A.setFromCoo( num_rows, num_cols, rows, cols, vals, true);
         CHECK( A.row_offsets() == std::vector{0,3,5,7});
         CHECK( A.column_indices() == std::vector{0,3,4,0,2,1,4});
         CHECK( A.values() == std::vector<double>{1,2,3,2,5,4,1});
@@ -181,8 +182,9 @@ TEST_CASE( "SpMV on device")
     // 2 0 5 0 0
     // 0 4 0 0 1
     unsigned num_rows = 3, num_cols = 5;
-    std::vector<int> rows = {0,3,5,7}, cols = {0,3,4,0,2,1,4};
-    std::vector<double> vals = {1,2,3,2,5,4,1};
+    // UNSORTED!!
+    std::vector<int> rows = {0,3,5,7}, cols = {0,4,3,0,2,1,4};
+    std::vector<double> vals = {1,3,2,2,5,4,1};
     dg::SparseMatrix<int,double,thrust::host_vector> A ( num_rows, num_cols, rows, cols, vals);
     dg::SparseMatrix<int,double, thrust::device_vector> dA( A);
     SECTION( "transpose")

--- a/inc/dg/backend/tensor_traits.h
+++ b/inc/dg/backend/tensor_traits.h
@@ -8,7 +8,12 @@
 #include "matrix_categories.h"
 #include "execution_policy.h"
 
-// TODO make inclusion of tensor_traits easier if all you want is to use the full traits system in feltor
+// Q: Make inclusion of tensor_traits easier if all you want is to use the full traits system in feltor?
+// A: Some subtle issues:
+// - Do you want the thrust header? (And thus depend on thrust library?)
+// - Do you want all matrix traits as well?
+// - If so, do you want the sparsematrix.h which incurs -lcusparse dependency
+// In fact, it is possible to include tensor_traits.h as is and include the specialisation later when it is needed
 
 namespace dg{
 ///@addtogroup dispatch

--- a/inc/dg/backend/tensor_traits_std.h
+++ b/inc/dg/backend/tensor_traits_std.h
@@ -7,6 +7,7 @@
 
 #include "vector_categories.h"
 #include "tensor_traits.h"
+#include "tensor_traits_scalar.h"
 #include "predicate.h"
 
 namespace dg

--- a/inc/dg/backend/tensor_traits_thrust.h
+++ b/inc/dg/backend/tensor_traits_thrust.h
@@ -5,6 +5,7 @@
 #include <thrust/complex.h>
 #include "vector_categories.h"
 #include "tensor_traits.h"
+#include "tensor_traits_scalar.h"
 
 namespace dg
 {

--- a/inc/dg/backend/traits_t.cpp
+++ b/inc/dg/backend/traits_t.cpp
@@ -4,7 +4,6 @@
 #include "backend/tensor_traits.h"
 #include "backend/tensor_traits_scalar.h"
 #include "backend/tensor_traits_thrust.h"
-#include "backend/tensor_traits_cusp.h"
 #include "backend/tensor_traits_std.h"
 
 #include "catch2/catch_all.hpp"

--- a/inc/dg/backend/typedefs.h
+++ b/inc/dg/backend/typedefs.h
@@ -3,6 +3,7 @@
 #include <thrust/host_vector.h>
 #include <thrust/device_vector.h>
 #include "sparseblockmat.h"
+#include "sparsematrix.h"
 
 /*! @file
   @brief Useful typedefs of commonly used types.
@@ -35,15 +36,15 @@ using fDMatrix = EllSparseBlockMat<float, thrust::device_vector>; //!< Device Ma
 
 // Interpolation matrices
 template<class real_type>
-using IHMatrix_t = cusp::csr_matrix<int, real_type, cusp::host_memory>;
+using IHMatrix_t = dg::SparseMatrix<int, real_type, thrust::host_vector>;
 template<class real_type>
 #if THRUST_DEVICE_SYSTEM==THRUST_DEVICE_SYSTEM_CUDA
 //Ell matrix can be almost 3x faster than csr for GPU
 //However, sometimes matrices contain outlier rows that do not fit in ell
-using IDMatrix_t = cusp::csr_matrix<int, real_type, cusp::device_memory>;
+using IDMatrix_t = dg::SparseMatrix<int, real_type, thrust::device_vector>;
 #else
 // csr matrix can be much faster than ell for CPU (we have our own symv implementation!)
-using IDMatrix_t = cusp::csr_matrix<int, real_type, cusp::device_memory>;
+using IDMatrix_t = dg::SparseMatrix<int, real_type, thrust::device_vector>;
 #endif
 using IHMatrix = IHMatrix_t<double>;
 using IDMatrix = IDMatrix_t<double>;

--- a/inc/dg/backend/view.h
+++ b/inc/dg/backend/view.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cusp/array1d.h>
 #include "tensor_traits.h"
 
 namespace dg

--- a/inc/dg/blas1.h
+++ b/inc/dg/blas1.h
@@ -4,11 +4,9 @@
 #include "backend/tensor_traits.h"
 #include "backend/tensor_traits_scalar.h"
 #include "backend/tensor_traits_thrust.h"
-#include "backend/tensor_traits_cusp.h"
 #include "backend/tensor_traits_std.h"
 #include "backend/blas1_dispatch_scalar.h"
 #include "backend/blas1_dispatch_shared.h"
-#include "backend/tensor_traits_cusp.h"
 #ifdef MPI_VERSION
 #include "backend/mpi_vector.h"
 #include "backend/blas1_dispatch_mpi.h"

--- a/inc/dg/blas1_t.cpp
+++ b/inc/dg/blas1_t.cpp
@@ -20,7 +20,6 @@
 //using Vector = thrust::host_vector<double>;
 using Vector = dg::x::DVec;
 using value_type = double;
-//using Vector = cusp::array1d<double, cusp::device_memory>;
 
 template<class Vector, class T>
 bool equal( const Vector& vec, T result)

--- a/inc/dg/blas2.h
+++ b/inc/dg/blas2.h
@@ -3,10 +3,8 @@
 #include "backend/tensor_traits.h"
 #include "backend/tensor_traits_std.h"
 #include "backend/tensor_traits_thrust.h"
-#include "backend/tensor_traits_cusp.h"
 #include "backend/blas2_dispatch_scalar.h"
 #include "backend/blas2_dispatch_shared.h"
-#include "backend/blas2_cusp.h"
 #include "backend/blas2_sparseblockmat.h"
 #include "backend/blas2_selfmade.h"
 #include "backend/blas2_densematrix.h"
@@ -448,7 +446,7 @@ inline void parallel_for( Stencil f, unsigned N, ContainerType&& x, ContainerTyp
  * @tparam FunctorType A type that is callable
  *  <tt> void operator()( unsigned, pointer, [m_pointers], const_pointer) </tt>  For GPU vector the functor
  *  must be callable on the device.
- * @tparam MatrixType So far only one of the \c cusp::csr_matrix types and their MPI variants <tt> dg::MPIDistMat<cusp::csr_matrix, Comm> </tt> are allowed
+ * @tparam MatrixType So far only one of the \c dg::SparseMatrix types and their MPI variants are allowed
  * @sa dg::CSRMedianFilter, dg::create::window_stencil
  * @copydoc hide_ContainerType
  */

--- a/inc/dg/helmholtz_b.cpp
+++ b/inc/dg/helmholtz_b.cpp
@@ -1,10 +1,5 @@
 #include <iostream>
 
-#include <cusp/precond/diagonal.h>
-#include <cusp/precond/ainv.h>
-#include <cusp/krylov/cg.h>
-#include <cusp/monitor.h>
-
 #include "blas.h"
 
 #include "backend/timer.h"

--- a/inc/dg/topology/Makefile
+++ b/inc/dg/topology/Makefile
@@ -65,13 +65,13 @@ mpi_average_t.$(device).o: average_t.cpp average.h
 	$(MPICC) $(OPT) $(MPICFLAGS) -c $< -o $@ -g $(INCLUDE) -DWITH_MPI
 
 %_t: $(CATCH).$(device).o %_t.$(device).o
-	$(CC) $(OPT) -o $@ $^ -lCatch2
+	$(CC) $(OPT) -o $@ $^ -lCatch2 $(SPARSELIB)
 
 mpi_%_t: $(CATCHMPI).$(device).o mpi_%_t.$(device).o
-	$(MPICC) $(OPT) -o $@ $^ -lCatch2
+	$(MPICC) $(OPT) -o $@ $^ -lCatch2 $(SPARSELIB)
 
 %_mpit: $(CATCHMPI).$(device).o %_mpit.$(device).o
-	$(MPICC) $(OPT) -o $@ $^ -lCatch2
+	$(MPICC) $(OPT) -o $@ $^ -lCatch2 $(SPARSELIB)
 
 $(CATCH).$(device).o: $(CATCH).cpp
 	$(CC) $(OPT) $(CFLAGS) $(INCLUDE) -g -c $< -o $@
@@ -80,10 +80,10 @@ $(CATCHMPI).$(device).o: $(CATCHMPI).cpp
 	$(MPICC) $(OPT) $(MPICFLAGS) $(INCLUDE) -g -c $< -o $@
 
 tests: $(CATCH).$(device).o $(addsuffix .$(device).o,$(TARGETS))
-	$(CC) -o $@ $^ -lCatch2
+	$(CC) -o $@ $^ -lCatch2 $(SPARSELIB)
 
 mpi-tests: $(CATCHMPI).$(device).o $(addsuffix .$(device).o,$(TARGETSMPI))
-	$(MPICC) -o $@ $^ -lCatch2
+	$(MPICC) -o $@ $^ -lCatch2 $(SPARSELIB)
 
 .PHONY: clean
 

--- a/inc/dg/topology/average.h
+++ b/inc/dg/topology/average.h
@@ -4,7 +4,6 @@
 #ifdef MPI_VERSION
 #include "mpi_prolongation.h"
 #endif
-#include <cusp/print.h>
 
 /*! @file
   @brief Classes for poloidal and toroidal average computations.

--- a/inc/dg/topology/evaluation_t.cpp
+++ b/inc/dg/topology/evaluation_t.cpp
@@ -275,7 +275,7 @@ TEST_CASE( "Dot throws")
     int rank;
     MPI_Comm_rank( MPI_COMM_WORLD, &rank);
     // only some ranks throw?
-    dg::MDVec x { dg::DVec{10, rank%2 == 0? -10 : +10}, MPI_COMM_WORLD};
+    dg::MDVec x { dg::DVec{10, rank%2 == 0? -10. : +10.}, MPI_COMM_WORLD};
 #else
     dg::DVec x(10, -10);
 #endif

--- a/inc/dg/topology/fast_interpolation.h
+++ b/inc/dg/topology/fast_interpolation.h
@@ -185,14 +185,14 @@ dg::HMatrix_t<real_type> fast_interpolation1d( const RealGrid1d<real_type>& t, u
     dg::RealGrid1d<real_type> g_old( -1., 1., n, 1);
     dg::RealGrid1d<real_type> g_new( -1., 1., n*multiplyn, multiplyNx);
     // Does not generate explicit zeros ...
-    cusp::coo_matrix<int, real_type, cusp::host_memory> interpolX =
+    cusp::csr_matrix<int, real_type, cusp::host_memory> interpolX =
         dg::create::interpolation( g_new, g_old);
     unsigned size = multiplyn*multiplyNx;
     EllSparseBlockMat<real_type, thrust::host_vector> iX( size*t.N(), t.N(), 1, size, t.n());
     dg::blas1::copy( 0., iX.data);
-    for( unsigned l=0; l<interpolX.num_entries; l++)
+    for( unsigned row=0; row<interpolX.num_rows; row++)
+    for( unsigned l=interpolX.row_offsets[row]; l<(unsigned)interpolX.row_offsets[row+1]; l++)
     {
-        int row = interpolX.row_indices[l];
         int col = interpolX.column_indices[l];
         real_type val = interpolX.values[l];
         iX.data[row*interpolX.num_cols + col] = val;
@@ -237,13 +237,13 @@ dg::HMatrix_t<real_type> fast_projection1d( const RealGrid1d<real_type>& t, unsi
     dg::RealGrid1d<real_type> g_old( -1., 1., n*dividen, divideNx);
     dg::RealGrid1d<real_type> g_new( -1., 1., n, 1);
     // Does not generate explicit zeros ...
-    cusp::coo_matrix<int, real_type, cusp::host_memory> projectX = dg::create::projection( g_new, g_old);
+    cusp::csr_matrix<int, real_type, cusp::host_memory> projectX = dg::create::projection( g_new, g_old);
     unsigned size = dividen*divideNx;
     EllSparseBlockMat<real_type, thrust::host_vector> pX( t.N()/divideNx, t.N()*dividen, size, size, n);
     dg::blas1::copy( 0., pX.data);
-    for( unsigned ll=0; ll<projectX.num_entries; ll++)
+    for( unsigned row=0; row<projectX.num_rows; row++)
+    for( unsigned ll=projectX.row_offsets[row]; ll<(unsigned)projectX.row_offsets[row+1]; ll++)
     {
-        int row = projectX.row_indices[ll];
         int col = projectX.column_indices[ll];
         real_type val = projectX.values[ll];
         int k = col/(n*dividen), l = (col/n)%dividen, i = row, j = col%n;

--- a/inc/dg/topology/fast_interpolation.h
+++ b/inc/dg/topology/fast_interpolation.h
@@ -185,17 +185,17 @@ dg::HMatrix_t<real_type> fast_interpolation1d( const RealGrid1d<real_type>& t, u
     dg::RealGrid1d<real_type> g_old( -1., 1., n, 1);
     dg::RealGrid1d<real_type> g_new( -1., 1., n*multiplyn, multiplyNx);
     // Does not generate explicit zeros ...
-    cusp::csr_matrix<int, real_type, cusp::host_memory> interpolX =
+    dg::SparseMatrix<int, real_type, thrust::host_vector> interpolX =
         dg::create::interpolation( g_new, g_old);
     unsigned size = multiplyn*multiplyNx;
     EllSparseBlockMat<real_type, thrust::host_vector> iX( size*t.N(), t.N(), 1, size, t.n());
     dg::blas1::copy( 0., iX.data);
-    for( unsigned row=0; row<interpolX.num_rows; row++)
-    for( unsigned l=interpolX.row_offsets[row]; l<(unsigned)interpolX.row_offsets[row+1]; l++)
+    for( unsigned row=0; row<interpolX.num_rows(); row++)
+    for( unsigned l=interpolX.row_offsets()[row]; l<(unsigned)interpolX.row_offsets()[row+1]; l++)
     {
-        int col = interpolX.column_indices[l];
-        real_type val = interpolX.values[l];
-        iX.data[row*interpolX.num_cols + col] = val;
+        int col = interpolX.column_indices()[l];
+        real_type val = interpolX.values()[l];
+        iX.data[row*interpolX.num_cols() + col] = val;
     }
     for( unsigned i=0; i<size*t.N(); i++)
     {
@@ -237,15 +237,15 @@ dg::HMatrix_t<real_type> fast_projection1d( const RealGrid1d<real_type>& t, unsi
     dg::RealGrid1d<real_type> g_old( -1., 1., n*dividen, divideNx);
     dg::RealGrid1d<real_type> g_new( -1., 1., n, 1);
     // Does not generate explicit zeros ...
-    cusp::csr_matrix<int, real_type, cusp::host_memory> projectX = dg::create::projection( g_new, g_old);
+    dg::SparseMatrix<int, real_type, thrust::host_vector> projectX = dg::create::projection( g_new, g_old);
     unsigned size = dividen*divideNx;
     EllSparseBlockMat<real_type, thrust::host_vector> pX( t.N()/divideNx, t.N()*dividen, size, size, n);
     dg::blas1::copy( 0., pX.data);
-    for( unsigned row=0; row<projectX.num_rows; row++)
-    for( unsigned ll=projectX.row_offsets[row]; ll<(unsigned)projectX.row_offsets[row+1]; ll++)
+    for( unsigned row=0; row<projectX.num_rows(); row++)
+    for( unsigned ll=projectX.row_offsets()[row]; ll<(unsigned)projectX.row_offsets()[row+1]; ll++)
     {
-        int col = projectX.column_indices[ll];
-        real_type val = projectX.values[ll];
+        int col = projectX.column_indices()[ll];
+        real_type val = projectX.values()[ll];
         int k = col/(n*dividen), l = (col/n)%dividen, i = row, j = col%n;
         pX.data[((k*dividen+l)*n+i)*n+j] = val;
     }

--- a/inc/dg/topology/fem.h
+++ b/inc/dg/topology/fem.h
@@ -53,32 +53,36 @@ struct TriDiagonal
     ///convert to a sparse matrix format
     dg::IHMatrix_t<value_type> asIMatrix() const{
         unsigned size = M.size();
-        cusp::coo_matrix<int,value_type,cusp::host_memory>  A( size, size, 3*size-2);
-        A.row_indices[0] = 0;
-        A.column_indices[0] = 0;
-        A.values[0] = O[0];
+        cusp::array1d<int, cusp::host_memory> A_row_offsets(size+1), A_column_indices( 3*size-2);
+        cusp::array1d<value_type, cusp::host_memory> A_values( 3*size-2);
+        A_row_offsets[0] = 0;
+        A_column_indices[0] = 0;
+        A_values[0] = O[0];
 
-        A.row_indices[1] = 0;
-        A.column_indices[1] = 1;
-        A.values[1] = P[0];
+        A_column_indices[1] = 1;
+        A_values[1] = P[0];
+
+        A_row_offsets[1] = 2;
 
         for( unsigned i=1;i<size; i++)
         {
-            A.row_indices[3*i-1+0] = i;
-            A.column_indices[3*i-1+0] = i-1;
-            A.values[3*i-1+0] = M[i];
+            A_column_indices[3*i-1+0] = i-1;
+            A_values[3*i-1+0] = M[i];
 
-            A.row_indices[3*i-1+1] = i;
-            A.column_indices[3*i-1+1] = i;
-            A.values[3*i-1+1] = O[i];
+            A_column_indices[3*i-1+1] = i;
+            A_values[3*i-1+1] = O[i];
 
             if( i != (size-1))
             {
-                A.row_indices[3*i-1+2] = i;
-                A.column_indices[3*i-1+2] = i+1;
-                A.values[3*i-1+2] = P[i];
+                A_column_indices[3*i-1+2] = i+1;
+                A_values[3*i-1+2] = P[i];
             }
+            A_row_offsets[i+1] = A_row_offsets[i] + ( i != (size-1) ? 3 : 2);
         }
+        cusp::csr_matrix<int,value_type,cusp::host_memory>  A( size, size, 3*size-2);
+        A.row_offsets = A_row_offsets;
+        A.column_indices = A_column_indices;
+        A.values = A_values;
         return dg::IHMatrix_t<value_type>(A);
     }
 

--- a/inc/dg/topology/fem.h
+++ b/inc/dg/topology/fem.h
@@ -22,6 +22,7 @@ namespace dg{
       \end{pmatrix}\f]
  * @tparam Container One of the shared memory containers
  * @ingroup sparsematrix
+ * @sa dg::mat::TridiagInvDF dg::mat::compute_Tinv_y
  */
 template<class Container>
 struct TriDiagonal
@@ -123,12 +124,13 @@ struct TriDiagonal
     Container P; //!< Uper diagonal ["Plus" +1] <tt>P[0]</tt> maps to <tt>T_01</tt>
 };
 
-/*!@brief Fast inverse tridiagonal sparse matrix
+///@addtogroup fem
+///@{
+/*!@brief DEPRECATED/UNTESTED Fast inverse tridiagonal sparse matrix
  *
  * When applied to a vector, uses Thomas algorithm to compute \f$ T^{-1} v\f$
  * @attention Only for shared memory host vectors
- * @ingroup sparsematrix
- * @sa dg::mat::TridiagInvDF
+ * @sa dg::mat::TridiagInvDF dg::mat::compute_Tinv_y
  */
 template<class value_type>
 struct InverseTriDiagonal
@@ -161,8 +163,6 @@ struct InverseTriDiagonal
     private:
     thrust::host_vector<value_type> M, O, P;
 };
-///@addtogroup fem
-///@{
 
 /*!@brief Fast tridiagonal sparse matrix in 2d \f$ T_y\otimes T_x\f$
  *

--- a/inc/dg/topology/fem.h
+++ b/inc/dg/topology/fem.h
@@ -7,15 +7,21 @@
 
 namespace dg{
 
-///@addtogroup fem
-///@{
 /*!@brief Fast (shared memory) tridiagonal sparse matrix
  *
  * Consists of the three diagonal vectors [M, O, P] (for "Minus" -1, "ZerO" 0,
- * "Plus +1 diagonal), i.e.  M is the subdiagonal, O the diagonal and P the
+ * "Plus +1), i.e.  M is the subdiagonal, O the diagonal and P the
  * superdiagonal vector.
  * \f$ M_0 \f$ and \f$ P_{N-1}\f$ are ignored
+    \f[ T = \begin{pmatrix}
+    O_0 & P_0 &   &   &   & \\
+    M_1 & O_1 & P_1 &   &   & \\
+      & M_2 & O_2 & P_2 &   & \\
+      &   & M_3 & O_3 & P_3 & \\
+      &   &   &...&   &
+      \end{pmatrix}\f]
  * @tparam Container One of the shared memory containers
+ * @ingroup sparsematrix
  */
 template<class Container>
 struct TriDiagonal
@@ -112,7 +118,7 @@ struct TriDiagonal
         return {size, size, A_row_offsets, A_column_indices, A_values};
     }
 
-    Container M; //!< Subdiagonal ["Minus" -1] <tt>M[0]</tt> maps to <tt>T_10</tt>
+    Container M; //!< Subdiagonal ["Minus" -1] <tt>M[0]</tt> is ignored <tt>M[1]</tt> maps to <tt>T_10</tt>
     Container O; //!< Diagonal ["zerO" 0]       <tt>O[0]</tt> maps to <tt>T_00</tt>
     Container P; //!< Uper diagonal ["Plus" +1] <tt>P[0]</tt> maps to <tt>T_01</tt>
 };
@@ -121,6 +127,8 @@ struct TriDiagonal
  *
  * When applied to a vector, uses Thomas algorithm to compute \f$ T^{-1} v\f$
  * @attention Only for shared memory host vectors
+ * @ingroup sparsematrix
+ * @sa dg::mat::TridiagInvDF
  */
 template<class value_type>
 struct InverseTriDiagonal
@@ -133,6 +141,7 @@ struct InverseTriDiagonal
         dg::assign( tri.P, this->P);
     }
 
+    /// \f$ x = T^{-1} y\f$
     void operator()( const thrust::host_vector<value_type>& y, thrust::host_vector<value_type>& x) const
     {
         unsigned size = M.size();
@@ -152,6 +161,8 @@ struct InverseTriDiagonal
     private:
     thrust::host_vector<value_type> M, O, P;
 };
+///@addtogroup fem
+///@{
 
 /*!@brief Fast tridiagonal sparse matrix in 2d \f$ T_y\otimes T_x\f$
  *

--- a/inc/dg/topology/fem_t.cpp
+++ b/inc/dg/topology/fem_t.cpp
@@ -9,7 +9,8 @@ static double function( double x, double y){return sin(x)*cos(y);}
 static double function( double x, double y, double z){return sin(x)*cos(y)*cos(z);}
 
 using Vector = dg::DVec;
-using Matrix = cusp::csr_matrix<int,double,cusp::device_memory>;
+using HMatrix = dg::SparseMatrix<int,double,thrust::host_vector>;
+using DMatrix = dg::SparseMatrix<int,double,thrust::device_vector>;
 using MassMatrix = dg::KroneckerTriDiagonal2d<Vector>;
 using InvMassMatrix = dg::InverseKroneckerTriDiagonal2d<Vector>;
 
@@ -35,11 +36,12 @@ TEST_CASE("FEM")
         dg::FemRefinement fem_ref( mx);
         dg::CartesianRefinedGrid2d gDIR_f( fem_ref, fem_ref, gDIR.x0(),
                 gDIR.x1(), gDIR.y0(), gDIR.y1(), n, Nx,Ny, dg::DIR, dg::DIR);
+        const Vector wf2d = dg::create::volume( gDIR_f);
         dg::HVec Xf = dg::pullback( dg::cooX2d, gDIR_f);
         dg::HVec Yf = dg::pullback( dg::cooY2d, gDIR_f);
-        Matrix inter = dg::create::interpolation( Xf, Yf, gDIR, dg::NEU,
-                dg::NEU, "linear");
-        const Vector wf2d = dg::create::volume( gDIR_f);
+        HMatrix interH = dg::create::interpolation( Xf, Yf, gDIR, dg::NEU,
+                    dg::NEU, "linear");
+        DMatrix inter = interH;
         Vector func_f( gDIR_f.size());
         dg::blas2::symv( inter, func, func_f);
         SECTION( "Integral")
@@ -52,13 +54,8 @@ TEST_CASE("FEM")
         SECTION( "PCG with FEM")
         {
             const Vector v2d = dg::create::fem_inv_weights( gDIR);
-            Matrix interT;
-            cusp::transpose( inter, interT);
-            Matrix Wf = dg::create::diagonal( (dg::HVec)wf2d), project;
-            Matrix Vf = dg::create::diagonal( (dg::HVec)v2d), tmp;
-            cusp::multiply( interT, Wf, tmp);
-            cusp::multiply( Vf, tmp, project);
-            //project.sort_by_row_and_column();
+            DMatrix project = dg::create::diagonal( (dg::HVec)v2d)*
+                interH.transpose()*dg::create::diagonal( (dg::HVec) wf2d);
 
             Vector barfunc(func);
             dg::blas2::symv( project, func_f, barfunc);
@@ -82,12 +79,9 @@ TEST_CASE("FEM")
             INFO("Thomas Distance to true solution: "<<norm/func_norm);
             CHECK( norm/ func_norm < 2e-14);
 
-            Matrix interC = dg::create::interpolation( Xf, Yf, gDIR, dg::NEU,
-                    dg::NEU, "nearest");
-            cusp::transpose( interC, interT);
-            cusp::multiply( interT, Wf, tmp);
-            cusp::multiply( Vf, tmp, project);
-            //project.sort_by_row_and_column();
+            project = dg::create::diagonal( (dg::HVec)v2d)*
+                dg::create::interpolation( Xf, Yf, gDIR, dg::NEU, dg::NEU,
+                "nearest").transpose()*dg::create::diagonal( (dg::HVec) wf2d);
             dg::blas2::symv( project, func_f, barfunc);
             fem_mass = dg::create::fem_linear2const( gDIR);
 

--- a/inc/dg/topology/fem_t.cpp
+++ b/inc/dg/topology/fem_t.cpp
@@ -9,11 +9,10 @@ static double function( double x, double y){return sin(x)*cos(y);}
 static double function( double x, double y, double z){return sin(x)*cos(y)*cos(z);}
 
 using Vector = dg::DVec;
-using Matrix = cusp::coo_matrix<int,double,cusp::device_memory>;
+using Matrix = cusp::csr_matrix<int,double,cusp::device_memory>;
 using MassMatrix = dg::KroneckerTriDiagonal2d<Vector>;
 using InvMassMatrix = dg::InverseKroneckerTriDiagonal2d<Vector>;
 
-// TODO This test fails! Fix it!
 TEST_CASE("FEM")
 {
     unsigned n = 3, Nx = 18, Ny = 24, mx = 3;
@@ -59,7 +58,7 @@ TEST_CASE("FEM")
             Matrix Vf = dg::create::diagonal( (dg::HVec)v2d), tmp;
             cusp::multiply( interT, Wf, tmp);
             cusp::multiply( Vf, tmp, project);
-            project.sort_by_row_and_column();
+            //project.sort_by_row_and_column();
 
             Vector barfunc(func);
             dg::blas2::symv( project, func_f, barfunc);
@@ -88,7 +87,7 @@ TEST_CASE("FEM")
             cusp::transpose( interC, interT);
             cusp::multiply( interT, Wf, tmp);
             cusp::multiply( Vf, tmp, project);
-            project.sort_by_row_and_column();
+            //project.sort_by_row_and_column();
             dg::blas2::symv( project, func_f, barfunc);
             fem_mass = dg::create::fem_linear2const( gDIR);
 

--- a/inc/dg/topology/interpolation.h
+++ b/inc/dg/topology/interpolation.h
@@ -1,7 +1,6 @@
 #pragma once
 //#include <iomanip>
 
-#include <cusp/csr_matrix.h>
 #include "dg/backend/typedefs.h"
 #include "dg/backend/view.h"
 #include "grid.h"
@@ -246,8 +245,8 @@ std::vector<real_type> choose_1d_abscissas( real_type X,
 template<class real_type>
 void interpolation_row( dg::space sp, real_type X,
     const RealGrid1d<real_type>& g, dg::bc bcx,
-    cusp::array1d<int, cusp::host_memory>& cols,
-    cusp::array1d<real_type, cusp::host_memory>& vals)
+    thrust::host_vector<int>& cols,
+    thrust::host_vector<real_type>& vals)
 {
     bool negative = false;
     detail::shift( negative, X, bcx, g.x0(), g.x1());
@@ -303,15 +302,15 @@ void interpolation_row( dg::space sp, real_type X,
 
 // dG interpolation
 template<class host_vector, class real_type>
-cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation1d(
+dg::SparseMatrix<int, real_type, thrust::host_vector> interpolation1d(
     dg::space sp,
     const host_vector& x, // can be a view...
     const RealGrid1d<real_type>& g,
     dg::bc bcx )
 {
-    cusp::array1d<real_type, cusp::host_memory> values;
-    cusp::array1d<int, cusp::host_memory> row_offsets;
-    cusp::array1d<int, cusp::host_memory> column_indices;
+    thrust::host_vector<real_type> values;
+    thrust::host_vector<int> row_offsets;
+    thrust::host_vector<int> column_indices;
     auto ptr = x.begin();
     row_offsets.push_back(0);
     for( unsigned i=0; i<x.size(); i++)
@@ -320,17 +319,12 @@ cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation1d(
         row_offsets.push_back( values.size());
         ptr++;
     }
-    cusp::csr_matrix<int, real_type, cusp::host_memory> A(
-            x.size(), g.size(), values.size());
-    A.row_offsets = row_offsets;
-    A.column_indices = column_indices;
-    A.values = values;
-    return A;
+    return {x.size(), g.size(), row_offsets, column_indices, values};
 }
 
 // nearest, linear or cubic interpolation
 template<class host_vector1, class host_vector2 >
-cusp::csr_matrix<int, dg::get_value_type<host_vector2>, cusp::host_memory> interpolation1d(
+dg::SparseMatrix<int, dg::get_value_type<host_vector2>, thrust::host_vector> interpolation1d(
         const host_vector1& x,
         const host_vector2& abs, // must be sorted
         dg::bc bcx, dg::get_value_type<host_vector2> x0, dg::get_value_type<host_vector2> x1,
@@ -339,9 +333,9 @@ cusp::csr_matrix<int, dg::get_value_type<host_vector2>, cusp::host_memory> inter
     using real_type = dg::get_value_type<host_vector2>;
     // boundary condidions for dg::Box likely won't work | Box is now removed
     // from library ...
-    cusp::array1d<real_type, cusp::host_memory> values;
-    cusp::array1d<int, cusp::host_memory> row_offsets;
-    cusp::array1d<int, cusp::host_memory> column_indices;
+    thrust::host_vector<real_type> values;
+    thrust::host_vector<int> row_offsets;
+    thrust::host_vector<int> column_indices;
     unsigned points_per_line = 1;
     if( method == "nearest")
         points_per_line = 1;
@@ -393,12 +387,7 @@ cusp::csr_matrix<int, dg::get_value_type<host_vector2>, cusp::host_memory> inter
             values.push_back( negative ? -1. : 1.);
         }
     }
-    cusp::csr_matrix<int, real_type, cusp::host_memory> A(
-            x.size(), abs.size(), values.size());
-    A.row_offsets = row_offsets;
-    A.column_indices = column_indices;
-    A.values = values;
-    return A;
+    return {x.size(), abs.size(), row_offsets, column_indices, values};
 }
 
 }//namespace detail
@@ -441,14 +430,14 @@ cusp::csr_matrix<int, dg::get_value_type<host_vector2>, cusp::host_memory> inter
  * @copydoc hide_method
  */
 template<class RecursiveHostVector, class real_type, size_t Nd>
-cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation(
+dg::SparseMatrix<int, real_type, thrust::host_vector> interpolation(
         const RecursiveHostVector& x,
         const aRealTopology<real_type, Nd>& g,
         std::array<dg::bc, Nd> bcx,
         std::string method = "dg")
 {
 
-    std::array<cusp::csr_matrix<int,real_type,cusp::host_memory>,Nd> axes;
+    std::array<dg::SparseMatrix<int,real_type,thrust::host_vector>,Nd> axes;
     for( unsigned u=0; u<Nd; u++)
     {
         if( x[u].size() != x[0].size())
@@ -488,7 +477,7 @@ cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation(
  * @attention removes explicit zeros in the interpolation matrix
  */
 template<class host_vector, class real_type, typename = std::enable_if_t<dg::is_vector_v<host_vector>>>
-cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation(
+dg::SparseMatrix<int, real_type, thrust::host_vector> interpolation(
         const host_vector& x,
         const RealGrid1d<real_type>& g,
         dg::bc bcx = dg::NEU,
@@ -522,7 +511,7 @@ cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation(
  * @attention removes explicit zeros in the interpolation matrix
  */
 template<class host_vector, class real_type>
-cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation(
+dg::SparseMatrix<int, real_type, thrust::host_vector> interpolation(
         const host_vector& x,
         const host_vector& y,
         const aRealTopology2d<real_type>& g,
@@ -560,7 +549,7 @@ cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation(
  * @attention all points (x, y, z) must lie within or on the boundaries of g
  */
 template<class host_vector, class real_type>
-cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation(
+dg::SparseMatrix<int, real_type, thrust::host_vector> interpolation(
         const host_vector& x,
         const host_vector& y,
         const host_vector& z,
@@ -594,7 +583,7 @@ cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation(
  * @attention Explicit zeros in the returned matrix are removed
  */
 template<class real_type, size_t Nd>
-cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation(
+dg::SparseMatrix<int, real_type, thrust::host_vector> interpolation(
     const aRealTopology<real_type,Nd>& g_new,
     const aRealTopology<real_type,Nd>& g_old, std::string method = "dg")
 {
@@ -608,7 +597,7 @@ cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation(
             std::cerr << "ERROR: New grid boundary number "<<u<<" with value "<<g_new.q(u)<<" lies outside old grid "<<g_old.q(u)<<" "<<g_old.q(u)-g_new.q(u)<<"\n";
         assert( g_new.q(u) <= g_old.q(u));
     }
-    std::array<cusp::csr_matrix<int,real_type,cusp::host_memory>,Nd> axes;
+    std::array<dg::SparseMatrix<int,real_type,thrust::host_vector>,Nd> axes;
     for( unsigned u=0; u<Nd; u++)
     {
         if( method == "dg")
@@ -660,8 +649,8 @@ real_type interpolate(
     dg::bc bcx = dg::NEU)
 {
     assert( v.size() == g.size());
-    cusp::array1d<real_type, cusp::host_memory> vals;
-    cusp::array1d<int, cusp::host_memory> cols;
+    thrust::host_vector<real_type> vals;
+    thrust::host_vector<int> cols;
     create::detail::interpolation_row( sp, x, g, bcx, cols, vals);
     //multiply x
     real_type value = 0;
@@ -698,11 +687,11 @@ real_type interpolate(
     dg::bc bcx = dg::NEU, dg::bc bcy = dg::NEU )
 {
     assert( v.size() == g.size());
-    cusp::array1d<real_type, cusp::host_memory> valsx;
-    cusp::array1d<int, cusp::host_memory> colsx;
+    thrust::host_vector<real_type> valsx;
+    thrust::host_vector<int> colsx;
     create::detail::interpolation_row( sp, x, g.gx(), bcx, colsx, valsx);
-    cusp::array1d<real_type, cusp::host_memory> valsy;
-    cusp::array1d<int, cusp::host_memory> colsy;
+    thrust::host_vector<real_type> valsy;
+    thrust::host_vector<int> colsy;
     create::detail::interpolation_row( sp, y, g.gy(), bcy, colsy, valsy);
     //multiply x
     real_type value = 0;

--- a/inc/dg/topology/interpolationX.h
+++ b/inc/dg/topology/interpolationX.h
@@ -24,7 +24,7 @@ namespace create{
  * @return interpolation matrix
  */
 template<class real_type>
-cusp::coo_matrix<int, real_type, cusp::host_memory> interpolation( const thrust::host_vector<real_type>& x, const RealGridX1d<real_type>& g)
+cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation( const thrust::host_vector<real_type>& x, const RealGridX1d<real_type>& g)
 {
     return interpolation( x, g.grid());
 }
@@ -41,7 +41,7 @@ cusp::coo_matrix<int, real_type, cusp::host_memory> interpolation( const thrust:
  * @return interpolation matrix
  */
 template<class real_type>
-cusp::coo_matrix<int, real_type, cusp::host_memory> interpolation( const thrust::host_vector<real_type>& x, const thrust::host_vector<real_type>& y, const aRealTopologyX2d<real_type>& g , dg::bc globalbcz = dg::NEU)
+cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation( const thrust::host_vector<real_type>& x, const thrust::host_vector<real_type>& y, const aRealTopologyX2d<real_type>& g , dg::bc globalbcz = dg::NEU)
 {
     return interpolation( x,y, g.grid(), globalbcz);
 }
@@ -62,7 +62,7 @@ cusp::coo_matrix<int, real_type, cusp::host_memory> interpolation( const thrust:
  * @note The values of x, y and z must lie within the boundaries of g
  */
 template<class real_type>
-cusp::coo_matrix<int, real_type, cusp::host_memory> interpolation( const thrust::host_vector<real_type>& x, const thrust::host_vector<real_type>& y, const thrust::host_vector<real_type>& z, const aRealTopologyX3d<real_type>& g, dg::bc globalbcz= dg::NEU)
+cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation( const thrust::host_vector<real_type>& x, const thrust::host_vector<real_type>& y, const thrust::host_vector<real_type>& z, const aRealTopologyX3d<real_type>& g, dg::bc globalbcz= dg::NEU)
 {
     return interpolation( x,y,z, g.grid(), globalbcz);
 }
@@ -80,7 +80,7 @@ cusp::coo_matrix<int, real_type, cusp::host_memory> interpolation( const thrust:
  * @note The boundaries of the old grid must lie within the boundaries of the new grid
  */
 template<class real_type>
-cusp::coo_matrix<int, real_type, cusp::host_memory> interpolation( const RealGridX1d<real_type>& g_new, const RealGridX1d<real_type>& g_old)
+cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation( const RealGridX1d<real_type>& g_new, const RealGridX1d<real_type>& g_old)
 {
     return interpolation( g_new.grid(), g_old.grid());
 }
@@ -97,7 +97,7 @@ cusp::coo_matrix<int, real_type, cusp::host_memory> interpolation( const RealGri
  * @note The boundaries of the old grid must lie within the boundaries of the new grid
  */
 template<class real_type>
-cusp::coo_matrix<int, real_type, cusp::host_memory> interpolation( const aRealTopologyX2d<real_type>& g_new, const aRealTopologyX2d<real_type>& g_old)
+cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation( const aRealTopologyX2d<real_type>& g_new, const aRealTopologyX2d<real_type>& g_old)
 {
     return interpolation( g_new.grid(), g_old.grid());
 }
@@ -115,7 +115,7 @@ cusp::coo_matrix<int, real_type, cusp::host_memory> interpolation( const aRealTo
  * @note The boundaries of the old grid must lie within the boundaries of the new grid
  */
 template<class real_type>
-cusp::coo_matrix<int, real_type, cusp::host_memory> interpolation( const aRealTopologyX3d<real_type>& g_new, const aRealTopologyX3d<real_type>& g_old)
+cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation( const aRealTopologyX3d<real_type>& g_new, const aRealTopologyX3d<real_type>& g_old)
 {
     return interpolation( g_new.grid(), g_old.grid());
 }

--- a/inc/dg/topology/interpolationX.h
+++ b/inc/dg/topology/interpolationX.h
@@ -24,7 +24,7 @@ namespace create{
  * @return interpolation matrix
  */
 template<class real_type>
-cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation( const thrust::host_vector<real_type>& x, const RealGridX1d<real_type>& g)
+dg::SparseMatrix<int, real_type, thrust::host_vector> interpolation( const thrust::host_vector<real_type>& x, const RealGridX1d<real_type>& g)
 {
     return interpolation( x, g.grid());
 }
@@ -41,7 +41,7 @@ cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation( const thrust:
  * @return interpolation matrix
  */
 template<class real_type>
-cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation( const thrust::host_vector<real_type>& x, const thrust::host_vector<real_type>& y, const aRealTopologyX2d<real_type>& g , dg::bc globalbcz = dg::NEU)
+dg::SparseMatrix<int, real_type, thrust::host_vector> interpolation( const thrust::host_vector<real_type>& x, const thrust::host_vector<real_type>& y, const aRealTopologyX2d<real_type>& g , dg::bc globalbcz = dg::NEU)
 {
     return interpolation( x,y, g.grid(), globalbcz);
 }
@@ -62,7 +62,7 @@ cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation( const thrust:
  * @note The values of x, y and z must lie within the boundaries of g
  */
 template<class real_type>
-cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation( const thrust::host_vector<real_type>& x, const thrust::host_vector<real_type>& y, const thrust::host_vector<real_type>& z, const aRealTopologyX3d<real_type>& g, dg::bc globalbcz= dg::NEU)
+dg::SparseMatrix<int, real_type, thrust::host_vector> interpolation( const thrust::host_vector<real_type>& x, const thrust::host_vector<real_type>& y, const thrust::host_vector<real_type>& z, const aRealTopologyX3d<real_type>& g, dg::bc globalbcz= dg::NEU)
 {
     return interpolation( x,y,z, g.grid(), globalbcz);
 }
@@ -80,7 +80,7 @@ cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation( const thrust:
  * @note The boundaries of the old grid must lie within the boundaries of the new grid
  */
 template<class real_type>
-cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation( const RealGridX1d<real_type>& g_new, const RealGridX1d<real_type>& g_old)
+dg::SparseMatrix<int, real_type, thrust::host_vector> interpolation( const RealGridX1d<real_type>& g_new, const RealGridX1d<real_type>& g_old)
 {
     return interpolation( g_new.grid(), g_old.grid());
 }
@@ -97,7 +97,7 @@ cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation( const RealGri
  * @note The boundaries of the old grid must lie within the boundaries of the new grid
  */
 template<class real_type>
-cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation( const aRealTopologyX2d<real_type>& g_new, const aRealTopologyX2d<real_type>& g_old)
+dg::SparseMatrix<int, real_type, thrust::host_vector> interpolation( const aRealTopologyX2d<real_type>& g_new, const aRealTopologyX2d<real_type>& g_old)
 {
     return interpolation( g_new.grid(), g_old.grid());
 }
@@ -115,7 +115,7 @@ cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation( const aRealTo
  * @note The boundaries of the old grid must lie within the boundaries of the new grid
  */
 template<class real_type>
-cusp::csr_matrix<int, real_type, cusp::host_memory> interpolation( const aRealTopologyX3d<real_type>& g_new, const aRealTopologyX3d<real_type>& g_old)
+dg::SparseMatrix<int, real_type, thrust::host_vector> interpolation( const aRealTopologyX3d<real_type>& g_new, const aRealTopologyX3d<real_type>& g_old)
 {
     return interpolation( g_new.grid(), g_old.grid());
 }

--- a/inc/dg/topology/interpolation_t.cpp
+++ b/inc/dg/topology/interpolation_t.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 
-#include <cusp/print.h>
 #include "xspacelib.h"
 #include "interpolation.h"
 #include "fast_interpolation.h"
@@ -14,7 +13,7 @@ static double function( double x, double y){return sin(x)*sin(y);}
 static double function( double x, double y, double z){return sin(x)*sin(y)*sin(z);}
 
 
-using Matrix = cusp::csr_matrix<int, double, cusp::host_memory>;
+using Matrix = dg::SparseMatrix<int, double, thrust::host_vector>;
 
 TEST_CASE( "Interpolation")
 {
@@ -35,9 +34,9 @@ TEST_CASE( "Interpolation")
 
         auto method = GENERATE( "dg", "nearest", "linear", "cubic");
         Matrix Xm = dg::create::interpolation( xminus, g1d, dg::DIR, method);
-        CHECK( Xm.values.size() == g1d.size());
+        CHECK( Xm.values().size() == g1d.size());
         Matrix Xp = dg::create::interpolation( xplus, g1d, dg::DIR, method);
-        CHECK( Xp.values.size() == g1d.size());
+        CHECK( Xp.values().size() == g1d.size());
     }
     SECTION( "1D equidist interpolate")
     {

--- a/inc/dg/topology/interpolation_t.cpp
+++ b/inc/dg/topology/interpolation_t.cpp
@@ -14,7 +14,7 @@ static double function( double x, double y){return sin(x)*sin(y);}
 static double function( double x, double y, double z){return sin(x)*sin(y)*sin(z);}
 
 
-using Matrix = cusp::coo_matrix<int, double, cusp::host_memory>;
+using Matrix = cusp::csr_matrix<int, double, cusp::host_memory>;
 
 TEST_CASE( "Interpolation")
 {

--- a/inc/dg/topology/mpi_projection.h
+++ b/inc/dg/topology/mpi_projection.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cusp/print.h>
 #include "dg/backend/typedefs.h"
 #include "dg/backend/index.h"
 #include "dg/backend/mpi_matrix.h"
@@ -61,7 +62,7 @@ dg::MIHMatrix_t<real_type> make_mpi_matrix(
     MPI_Comm_rank( col_policy.communicator(), &rank);
 
     const dg::IHMatrix_t<real_type>& A = global_cols;
-    std::vector<int> outer_row( A.num_rows, 0);
+    std::vector<int> global_row( A.num_rows, 0);
     // 1st pass determine local rows
     for(int i = 0; i < (int)A.num_rows; i++)
     for (int jj = A.row_offsets[i]; jj < A.row_offsets[i+1]; jj++)
@@ -69,60 +70,64 @@ dg::MIHMatrix_t<real_type> make_mpi_matrix(
         int lIdx=0, pid = 0;
         assert( col_policy.global2localIdx( A.column_indices[jj], lIdx, pid));
         if( pid != rank)
-            outer_row[i] = 1;
+            global_row[i] = 1;
     }
 
     // 2nd pass: distribute entries
     thrust::host_vector<std::array<int,2>> outer_col;
-    cusp::array1d<int, cusp::host_memory> inner_row, inner_col, buffer_row;
+    cusp::array1d<int, cusp::host_memory> inner_row, inner_col, outer_row;
     cusp::array1d<real_type, cusp::host_memory> inner_val, outer_val;
-    int buffer_row_idx = 0;
     thrust::host_vector<int> row_scatter;
+    inner_row.push_back(0);
+    outer_row.push_back(0);
     for(int i = 0; i < (int)A.num_rows; i++)
     {
         for (int jj = A.row_offsets[i]; jj < A.row_offsets[i+1]; jj++)
         {
             int lIdx=0, pid = 0;
             col_policy.global2localIdx( A.column_indices[jj], lIdx, pid);
-            if( outer_row[i] == 1)
+            if( global_row[i] == 1)
             {
-                buffer_row.push_back( buffer_row_idx);
                 outer_col.push_back( {pid,lIdx});
                 outer_val.push_back( A.values[jj]);
             }
             else
             {
-                inner_row.push_back( i);
                 inner_col.push_back( lIdx);
                 inner_val.push_back( A.values[jj]);
             }
         }
-        if( outer_row[i] == 1)
+        if( global_row[i] == 1)
         {
-            buffer_row_idx++;
             row_scatter.push_back(i);
+            int old_end = outer_row.back();
+            outer_row.push_back( old_end + A.row_offsets[i+1] - A.row_offsets[i]);
+            inner_row.push_back( inner_row[i]);
+        }
+        else
+        {
+            inner_row.push_back( inner_row[i] + A.row_offsets[i+1] - A.row_offsets[i]);
         }
     }
     // 3. Now make MPI Gather object
+    cusp::csr_matrix<int, real_type, cusp::host_memory> inner( A.num_rows,
+            col_policy.local_size(), inner_val.size());
+    inner.row_offsets    = inner_row;
+    inner.column_indices = inner_col;
+    inner.values         = inner_val;
+
     thrust::host_vector<int> lColIdx;
     auto gather_map = dg::gIdx2unique_idx( outer_col, lColIdx);
     MPIGather<thrust::host_vector> mpi_gather( gather_map,
             col_policy.communicator());
-    cusp::coo_matrix<int, real_type, cusp::host_memory> inner( A.num_rows,
-            col_policy.local_size(), inner_val.size());
-    inner.row_indices    = inner_row;
-    inner.column_indices = inner_col;
-    inner.values         = inner_val;
-    if( inner.row_indices.size() > 0)
-        inner.sort_by_row_and_column();
-    cusp::coo_matrix<int, real_type, cusp::host_memory> outer( buffer_row_idx,
+
+    cusp::csr_matrix<int, real_type, cusp::host_memory> outer( outer_row.size()-1,
             mpi_gather.buffer_size(), outer_val.size());
-    outer.row_indices    = buffer_row;
+    outer.row_offsets    = outer_row;
     outer.column_indices = lColIdx;
     outer.values         = outer_val;
-    if( outer.row_indices.size() > 0)
-        outer.sort_by_row_and_column();
-    return { inner, outer, mpi_gather, row_scatter}; // implicitly convert
+
+    return { inner, outer, mpi_gather, row_scatter};
 }
 
 
@@ -169,8 +174,11 @@ dg::IHMatrix_t<real_type> convertGlobal2LocalRows( const
 {
     // 0. Convert to coo matrix
     cusp::coo_matrix<int, real_type, cusp::host_memory> A = global;
+    //cusp::array1d<real_type, cusp::host_memory> global_row_indices = dg::csr2coo( global.row_offsets);
+
     // 1. For all rows determine pid to which it belongs
     auto gIdx = dg::gIdx2gIdx( A.row_indices, row_policy);
+    //auto gIdx = dg::gIdx2gIdx( global_row_indices, row_policy);
     std::map<int, cusp::array1d<int, cusp::host_memory>> rows, cols;
     std::map<int, cusp::array1d<real_type, cusp::host_memory>> vals;
     for( unsigned u=0; u<gIdx.size(); u++)
@@ -178,6 +186,8 @@ dg::IHMatrix_t<real_type> convertGlobal2LocalRows( const
         rows[gIdx[u][0]].push_back( gIdx[u][1]);
         cols[gIdx[u][0]].push_back( A.column_indices[u]);
         vals[gIdx[u][0]].push_back( A.values[u]);
+        //cols[gIdx[u][0]].push_back( global.column_indices[u]);
+        //vals[gIdx[u][0]].push_back( global.values[u]);
     }
     // 2. Now send those rows to where they belong
     auto row_buf = dg::mpi_permute( rows, row_policy.communicator());
@@ -185,11 +195,14 @@ dg::IHMatrix_t<real_type> convertGlobal2LocalRows( const
     auto val_buf = dg::mpi_permute( vals, row_policy.communicator());
 
     cusp::coo_matrix<int, real_type, cusp::host_memory> B(
+    //cusp::csr_matrix<int, real_type, cusp::host_memory> B(
         row_policy.local_size(), global.num_cols,
         dg::detail::flatten_map(row_buf).size());
-    B.row_indices    = dg::detail::flatten_map(row_buf);
+    B.row_indices    = dg::detail::flatten_map( row_buf);
+    //B.row_offsets    = dg::coo2csr( row_policy.local_size(), dg::detail::flatten_map(row_buf));
     B.column_indices = dg::detail::flatten_map(col_buf);
     B.values         = dg::detail::flatten_map(val_buf);
+    // indices come in any order ( so we need to sort)
     if( B.row_indices.size() > 0) // BugFix
         B.sort_by_row_and_column();
     return dg::IHMatrix_t<real_type>(B);

--- a/inc/dg/topology/mpi_projection.h
+++ b/inc/dg/topology/mpi_projection.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cusp/print.h>
 #include "dg/backend/typedefs.h"
 #include "dg/backend/index.h"
 #include "dg/backend/mpi_matrix.h"
@@ -62,70 +61,64 @@ dg::MIHMatrix_t<real_type> make_mpi_matrix(
     MPI_Comm_rank( col_policy.communicator(), &rank);
 
     const dg::IHMatrix_t<real_type>& A = global_cols;
-    std::vector<int> global_row( A.num_rows, 0);
+    std::vector<int> global_row( A.num_rows(), 0);
     // 1st pass determine local rows
-    for(int i = 0; i < (int)A.num_rows; i++)
-    for (int jj = A.row_offsets[i]; jj < A.row_offsets[i+1]; jj++)
+    for(int i = 0; i < (int)A.num_rows(); i++)
+    for (int jj = A.row_offsets()[i]; jj < A.row_offsets()[i+1]; jj++)
     {
         int lIdx=0, pid = 0;
-        assert( col_policy.global2localIdx( A.column_indices[jj], lIdx, pid));
+        assert( col_policy.global2localIdx( A.column_indices()[jj], lIdx, pid));
         if( pid != rank)
             global_row[i] = 1;
     }
 
     // 2nd pass: distribute entries
     thrust::host_vector<std::array<int,2>> outer_col;
-    cusp::array1d<int, cusp::host_memory> inner_row, inner_col, outer_row;
-    cusp::array1d<real_type, cusp::host_memory> inner_val, outer_val;
+    thrust::host_vector<int> inner_row, inner_col, outer_row;
+    thrust::host_vector<real_type> inner_val, outer_val;
     thrust::host_vector<int> row_scatter;
     inner_row.push_back(0);
     outer_row.push_back(0);
-    for(int i = 0; i < (int)A.num_rows; i++)
+    for(int i = 0; i < (int)A.num_rows(); i++)
     {
-        for (int jj = A.row_offsets[i]; jj < A.row_offsets[i+1]; jj++)
+        for (int jj = A.row_offsets()[i]; jj < A.row_offsets()[i+1]; jj++)
         {
             int lIdx=0, pid = 0;
-            col_policy.global2localIdx( A.column_indices[jj], lIdx, pid);
+            col_policy.global2localIdx( A.column_indices()[jj], lIdx, pid);
             if( global_row[i] == 1)
             {
                 outer_col.push_back( {pid,lIdx});
-                outer_val.push_back( A.values[jj]);
+                outer_val.push_back( A.values()[jj]);
             }
             else
             {
                 inner_col.push_back( lIdx);
-                inner_val.push_back( A.values[jj]);
+                inner_val.push_back( A.values()[jj]);
             }
         }
         if( global_row[i] == 1)
         {
             row_scatter.push_back(i);
             int old_end = outer_row.back();
-            outer_row.push_back( old_end + A.row_offsets[i+1] - A.row_offsets[i]);
+            outer_row.push_back( old_end + A.row_offsets()[i+1] - A.row_offsets()[i]);
             inner_row.push_back( inner_row[i]);
         }
         else
         {
-            inner_row.push_back( inner_row[i] + A.row_offsets[i+1] - A.row_offsets[i]);
+            inner_row.push_back( inner_row[i] + A.row_offsets()[i+1] - A.row_offsets()[i]);
         }
     }
     // 3. Now make MPI Gather object
-    cusp::csr_matrix<int, real_type, cusp::host_memory> inner( A.num_rows,
-            col_policy.local_size(), inner_val.size());
-    inner.row_offsets    = inner_row;
-    inner.column_indices = inner_col;
-    inner.values         = inner_val;
+    dg::SparseMatrix<int, real_type, thrust::host_vector> inner( A.num_rows(),
+            col_policy.local_size(), inner_row, inner_col, inner_val);
 
     thrust::host_vector<int> lColIdx;
     auto gather_map = dg::gIdx2unique_idx( outer_col, lColIdx);
     MPIGather<thrust::host_vector> mpi_gather( gather_map,
             col_policy.communicator());
 
-    cusp::csr_matrix<int, real_type, cusp::host_memory> outer( outer_row.size()-1,
-            mpi_gather.buffer_size(), outer_val.size());
-    outer.row_offsets    = outer_row;
-    outer.column_indices = lColIdx;
-    outer.values         = outer_val;
+    dg::SparseMatrix<int, real_type, thrust::host_vector> outer( outer_row.size()-1,
+            mpi_gather.buffer_size(), outer_row, lColIdx, outer_val);
 
     return { inner, outer, mpi_gather, row_scatter};
 }
@@ -173,39 +166,30 @@ dg::IHMatrix_t<real_type> convertGlobal2LocalRows( const
     dg::IHMatrix_t<real_type>& global, const ConversionPolicy& row_policy)
 {
     // 0. Convert to coo matrix
-    cusp::coo_matrix<int, real_type, cusp::host_memory> A = global;
-    //cusp::array1d<real_type, cusp::host_memory> global_row_indices = dg::csr2coo( global.row_offsets);
+    thrust::host_vector<int> global_row_indices = dg::detail::csr2coo( global.row_offsets());
 
     // 1. For all rows determine pid to which it belongs
-    auto gIdx = dg::gIdx2gIdx( A.row_indices, row_policy);
-    //auto gIdx = dg::gIdx2gIdx( global_row_indices, row_policy);
-    std::map<int, cusp::array1d<int, cusp::host_memory>> rows, cols;
-    std::map<int, cusp::array1d<real_type, cusp::host_memory>> vals;
+    auto gIdx = dg::gIdx2gIdx( global_row_indices, row_policy);
+    std::map<int, thrust::host_vector<int>> rows, cols;
+    std::map<int, thrust::host_vector<real_type>> vals;
     for( unsigned u=0; u<gIdx.size(); u++)
     {
         rows[gIdx[u][0]].push_back( gIdx[u][1]);
-        cols[gIdx[u][0]].push_back( A.column_indices[u]);
-        vals[gIdx[u][0]].push_back( A.values[u]);
-        //cols[gIdx[u][0]].push_back( global.column_indices[u]);
-        //vals[gIdx[u][0]].push_back( global.values[u]);
+        cols[gIdx[u][0]].push_back( global.column_indices()[u]);
+        vals[gIdx[u][0]].push_back( global.values()[u]);
     }
     // 2. Now send those rows to where they belong
     auto row_buf = dg::mpi_permute( rows, row_policy.communicator());
     auto col_buf = dg::mpi_permute( cols, row_policy.communicator());
     auto val_buf = dg::mpi_permute( vals, row_policy.communicator());
 
-    cusp::coo_matrix<int, real_type, cusp::host_memory> B(
-    //cusp::csr_matrix<int, real_type, cusp::host_memory> B(
-        row_policy.local_size(), global.num_cols,
-        dg::detail::flatten_map(row_buf).size());
-    B.row_indices    = dg::detail::flatten_map( row_buf);
-    //B.row_offsets    = dg::coo2csr( row_policy.local_size(), dg::detail::flatten_map(row_buf));
-    B.column_indices = dg::detail::flatten_map(col_buf);
-    B.values         = dg::detail::flatten_map(val_buf);
+    dg::SparseMatrix<int, real_type, thrust::host_vector> B;
     // indices come in any order ( so we need to sort)
-    if( B.row_indices.size() > 0) // BugFix
-        B.sort_by_row_and_column();
-    return dg::IHMatrix_t<real_type>(B);
+    B.setFromCoo( row_policy.local_size(), global.num_cols(),
+        dg::detail::flatten_map( row_buf),
+        dg::detail::flatten_map(col_buf),
+        dg::detail::flatten_map(val_buf));
+    return B;
     // 4. Reduce on identical rows/cols
     // .... Maybe later
 }
@@ -248,10 +232,11 @@ void convertLocal2GlobalCols( dg::IHMatrix_t<real_type>& local, const Conversion
     // 1. For all columns determine pid to which it belongs
     int rank=0;
     MPI_Comm_rank( policy.communicator(), &rank);
+    thrust::host_vector<int> local_cols = local.column_indices();
 
-    for(unsigned i=0; i<local.column_indices.size(); i++)
-        assert( policy.local2globalIdx(local.column_indices[i], rank, local.column_indices[i]) );
-    local.num_cols = policy.size();
+    for(unsigned i=0; i<local.column_indices().size(); i++)
+        assert( policy.local2globalIdx(local_cols[i], rank, local_cols[i]) );
+    local.set( local.num_rows(), policy.size(), local.row_offsets(), local_cols, local.values());
 }
 
 namespace create

--- a/inc/dg/topology/mpi_projection.h
+++ b/inc/dg/topology/mpi_projection.h
@@ -188,7 +188,7 @@ dg::IHMatrix_t<real_type> convertGlobal2LocalRows( const
     B.setFromCoo( row_policy.local_size(), global.num_cols(),
         dg::detail::flatten_map( row_buf),
         dg::detail::flatten_map(col_buf),
-        dg::detail::flatten_map(val_buf));
+        dg::detail::flatten_map(val_buf), true);
     return B;
     // 4. Reduce on identical rows/cols
     // .... Maybe later

--- a/inc/dg/topology/operator.h
+++ b/inc/dg/topology/operator.h
@@ -125,6 +125,13 @@ class SquareMatrix
      * @return
      */
     const std::vector<value_type>& data() const {return data_;}
+    /**
+     * @brief Write access to underlying data
+     *
+     * @attention If you resize the data everything bad that happens is on you
+     * @return
+     */
+    std::vector<value_type>& data() {return data_;}
 
     /**
      * @brief Swap two lines in the square matrix

--- a/inc/dg/topology/operator_tensor.h
+++ b/inc/dg/topology/operator_tensor.h
@@ -95,7 +95,7 @@ dg::SparseMatrix<int, T, thrust::host_vector> sandwich( const SquareMatrix<T>& l
     assert( left.size() == right.size());
     unsigned n = left.size();
     unsigned N = m.num_rows()/n;
-    return tensorproduct( N, left)*m*tensorproduct( N, right);
+    return tensorproduct( N, left)*(m*tensorproduct( N, right));
 }
 
 

--- a/inc/dg/topology/operator_tensor_t.cpp
+++ b/inc/dg/topology/operator_tensor_t.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 
-#include <cusp/coo_matrix.h>
 
 #include "dlt.h"
 #include "functions.h"
@@ -28,14 +27,14 @@ TEST_CASE( "SquareMatrix tensorproduct")
         CHECK( op(i+6,k+6) == Op2(i,k));
     }
 
-    cusp::coo_matrix<int, double, cusp::host_memory> test2 = dg::tensorproduct(
+    cusp::csr_matrix<int, double, cusp::host_memory> test2 = dg::tensorproduct(
         2, Op2);
-    std::vector<int> row = {0,0,0,1,1,1,2,2,2,3,3,3,4,4,4,5,5,5};
+    std::vector<int> row = {0,3,6,9,12,15,18};
     std::vector<int> col = {0,1,2,0,1,2,0,1,2,3,4,5,3,4,5,3,4,5};
     cusp::array1d<double, cusp::host_memory> val( 18);
     thrust::copy( Op2.data().begin(), Op2.data().end(), val.begin());
     thrust::copy( Op2.data().begin(), Op2.data().end(), val.begin()+9);
-    CHECK( row == test2.row_indices);
+    CHECK( row == test2.row_offsets);
     CHECK( col == test2.column_indices);
     CHECK( val == test2.values);
 }

--- a/inc/dg/topology/operator_tensor_t.cpp
+++ b/inc/dg/topology/operator_tensor_t.cpp
@@ -27,14 +27,13 @@ TEST_CASE( "SquareMatrix tensorproduct")
         CHECK( op(i+6,k+6) == Op2(i,k));
     }
 
-    cusp::csr_matrix<int, double, cusp::host_memory> test2 = dg::tensorproduct(
-        2, Op2);
+    auto test2 = dg::tensorproduct( 2, Op2);
     std::vector<int> row = {0,3,6,9,12,15,18};
     std::vector<int> col = {0,1,2,0,1,2,0,1,2,3,4,5,3,4,5,3,4,5};
-    cusp::array1d<double, cusp::host_memory> val( 18);
+    thrust::host_vector<double> val( 18);
     thrust::copy( Op2.data().begin(), Op2.data().end(), val.begin());
     thrust::copy( Op2.data().begin(), Op2.data().end(), val.begin()+9);
-    CHECK( row == test2.row_offsets);
-    CHECK( col == test2.column_indices);
-    CHECK( val == test2.values);
+    CHECK( row == test2.row_offsets());
+    CHECK( col == test2.column_indices());
+    CHECK( val == test2.values());
 }

--- a/inc/dg/topology/projection.h
+++ b/inc/dg/topology/projection.h
@@ -135,8 +135,14 @@ dg::SparseMatrix< int, real_type, thrust::host_vector> projection(
     //form the adjoint
     auto w_old = dg::create::weights( g_old);
     auto v_new = dg::create::inv_weights( g_new);
-    return dg::create::diagonal( v_new)* interpolation(
-            g_old, g_new, method).transpose() * dg::create::diagonal(w_old);
+    auto project = interpolation( g_old, g_new, method).transpose();
+    for( unsigned row=0; row<project.num_rows(); row++)
+        for ( int jj = project.row_offsets()[row]; jj < project.row_offsets()[row+1]; jj++)
+        {
+            int col = project.column_indices()[jj];
+            project.values()[jj] = v_new[row] * ( project.values()[jj]* w_old[col]);
+        }
+    return project;
 }
 
 /**

--- a/inc/dg/topology/projection.h
+++ b/inc/dg/topology/projection.h
@@ -140,6 +140,7 @@ dg::SparseMatrix< int, real_type, thrust::host_vector> projection(
         for ( int jj = project.row_offsets()[row]; jj < project.row_offsets()[row+1]; jj++)
         {
             int col = project.column_indices()[jj];
+            // Note that w_old is multiplied before v_new (keeps results backwards reproducible)
             project.values()[jj] = v_new[row] * ( project.values()[jj]* w_old[col]);
         }
     return project;

--- a/inc/dg/topology/projectionX.h
+++ b/inc/dg/topology/projectionX.h
@@ -13,19 +13,19 @@ namespace create{
 
 // TODO document
 template<class real_type>
-cusp::csr_matrix< int, real_type, cusp::host_memory> projection( const RealGridX1d<real_type>& g_new, const RealGridX1d<real_type>& g_old,std::string method = "dg") {
+dg::SparseMatrix< int, real_type, thrust::host_vector> projection( const RealGridX1d<real_type>& g_new, const RealGridX1d<real_type>& g_old,std::string method = "dg") {
     return projection(g_new.grid(), g_old.grid(),method);
 }
 
 // TODO document
 template<class real_type>
-cusp::csr_matrix< int, real_type, cusp::host_memory> projection( const aRealTopologyX2d<real_type>& g_new, const aRealTopologyX2d<real_type>& g_old,std::string method = "dg") {
+dg::SparseMatrix< int, real_type, thrust::host_vector> projection( const aRealTopologyX2d<real_type>& g_new, const aRealTopologyX2d<real_type>& g_old,std::string method = "dg") {
     return projection(g_new.grid(), g_old.grid(),method);
 }
 
 // TODO document
 template<class real_type>
-cusp::csr_matrix< int, real_type, cusp::host_memory> projection( const aRealTopologyX3d<real_type>& g_new, const aRealTopologyX3d<real_type>& g_old,std::string method = "dg") {
+dg::SparseMatrix< int, real_type, thrust::host_vector> projection( const aRealTopologyX3d<real_type>& g_new, const aRealTopologyX3d<real_type>& g_old,std::string method = "dg") {
     return projection(g_new.grid(), g_old.grid(),method);
 }
 

--- a/inc/dg/topology/projectionX.h
+++ b/inc/dg/topology/projectionX.h
@@ -13,19 +13,19 @@ namespace create{
 
 // TODO document
 template<class real_type>
-cusp::coo_matrix< int, real_type, cusp::host_memory> projection( const RealGridX1d<real_type>& g_new, const RealGridX1d<real_type>& g_old,std::string method = "dg") {
+cusp::csr_matrix< int, real_type, cusp::host_memory> projection( const RealGridX1d<real_type>& g_new, const RealGridX1d<real_type>& g_old,std::string method = "dg") {
     return projection(g_new.grid(), g_old.grid(),method);
 }
 
 // TODO document
 template<class real_type>
-cusp::coo_matrix< int, real_type, cusp::host_memory> projection( const aRealTopologyX2d<real_type>& g_new, const aRealTopologyX2d<real_type>& g_old,std::string method = "dg") {
+cusp::csr_matrix< int, real_type, cusp::host_memory> projection( const aRealTopologyX2d<real_type>& g_new, const aRealTopologyX2d<real_type>& g_old,std::string method = "dg") {
     return projection(g_new.grid(), g_old.grid(),method);
 }
 
 // TODO document
 template<class real_type>
-cusp::coo_matrix< int, real_type, cusp::host_memory> projection( const aRealTopologyX3d<real_type>& g_new, const aRealTopologyX3d<real_type>& g_old,std::string method = "dg") {
+cusp::csr_matrix< int, real_type, cusp::host_memory> projection( const aRealTopologyX3d<real_type>& g_new, const aRealTopologyX3d<real_type>& g_old,std::string method = "dg") {
     return projection(g_new.grid(), g_old.grid(),method);
 }
 

--- a/inc/dg/topology/prolongation.h
+++ b/inc/dg/topology/prolongation.h
@@ -170,6 +170,7 @@ dg::SparseMatrix<int, real_type, thrust::host_vector> projection(
         for ( int jj = project.row_offsets()[row]; jj < project.row_offsets()[row+1]; jj++)
         {
             int col = project.column_indices()[jj];
+            // Note that w_old is multiplied before v_new (keeps results backwards reproducible)
             project.values()[jj] = v_new[row] * ( project.values()[jj]* w_old[col]);
         }
     return project;

--- a/inc/dg/topology/prolongation.h
+++ b/inc/dg/topology/prolongation.h
@@ -128,14 +128,13 @@ cusp::csr_matrix<int, real_type, cusp::host_memory> prolongation(
  * @sa Reduction is the transpose of a \c prolongation
  */
 template<class real_type, size_t Nd, size_t Md>
-cusp::coo_matrix<int, real_type, cusp::host_memory> reduction(
+cusp::csr_matrix<int, real_type, cusp::host_memory> reduction(
     std::array<unsigned,Md> axes,
     const aRealTopology<real_type,Nd>& g_old)
 {
-    cusp::coo_matrix<int, real_type, cusp::host_memory> temp = prolongation(
+    cusp::csr_matrix<int, real_type, cusp::host_memory> temp = prolongation(
             g_old, axes), A;
     cusp::transpose( temp, A);
-    A.sort_by_row_and_column();
     return A;
 }
 
@@ -158,7 +157,7 @@ cusp::coo_matrix<int, real_type, cusp::host_memory> reduction(
  * @sa Projection is the adjoint of a \c prolongation
  */
 template<class real_type, size_t Nd, size_t Md>
-cusp::coo_matrix<int, real_type, cusp::host_memory> projection(
+cusp::csr_matrix<int, real_type, cusp::host_memory> projection(
     std::array<unsigned,Md> axes,
     const aRealTopology<real_type,Nd>& g_old)
 {
@@ -169,14 +168,14 @@ cusp::coo_matrix<int, real_type, cusp::host_memory> projection(
     RealGrid<real_type, Nd-Md> g_new(gs);
     auto w_old = dg::create::weights( g_old);
     auto v_new = dg::create::inv_weights( g_new);
-    cusp::coo_matrix<int, real_type, cusp::host_memory> temp = prolongation(
+    cusp::csr_matrix<int, real_type, cusp::host_memory> temp = prolongation(
             g_old, axes), A;
     cusp::transpose( temp, A);
     auto Wf = dg::create::diagonal( w_old);
     auto Vc = dg::create::diagonal( v_new);
     cusp::multiply( A, Wf, temp);
     cusp::multiply( Vc, temp, A);
-    A.sort_by_row_and_column();
+    //A.sort_by_row_and_column();
     return A;
 }
 ///@}

--- a/inc/dg/topology/prolongation.h
+++ b/inc/dg/topology/prolongation.h
@@ -165,8 +165,14 @@ dg::SparseMatrix<int, real_type, thrust::host_vector> projection(
     RealGrid<real_type, Nd-Md> g_new(gs);
     auto w_old = dg::create::weights( g_old);
     auto v_new = dg::create::inv_weights( g_new);
-    return dg::create::diagonal( v_new)* prolongation(
-            g_old, axes).transpose() * dg::create::diagonal(w_old);
+    auto project = prolongation( g_old, axes).transpose();
+    for( unsigned row=0; row<project.num_rows(); row++)
+        for ( int jj = project.row_offsets()[row]; jj < project.row_offsets()[row+1]; jj++)
+        {
+            int col = project.column_indices()[jj];
+            project.values()[jj] = v_new[row] * ( project.values()[jj]* w_old[col]);
+        }
+    return project;
 }
 ///@}
 

--- a/inc/dg/topology/refined_grid.h
+++ b/inc/dg/topology/refined_grid.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "cusp/transpose.h"
 #include "dg/backend/memory.h"
 #include "dg/blas.h"
 #include "grid.h"

--- a/inc/dg/topology/refined_gridX.h
+++ b/inc/dg/topology/refined_gridX.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "cusp/transpose.h"
 #include "interpolation.h"
 #include "evaluationX.h"
 #include "weightsX.h"

--- a/inc/dg/topology/stencil.h
+++ b/inc/dg/topology/stencil.h
@@ -17,11 +17,12 @@ namespace detail
 {
 template<class real_type>
     void set_boundary(
-        cusp::array1d<real_type, cusp::host_memory>& values,
-        cusp::array1d<int, cusp::host_memory>& column_indices,
+        thrust::host_vector<real_type>& values,
+        thrust::host_vector<int>& column_indices,
         dg::bc bcx,
         int num_cols)
 {
+    // Fix this leads to duplicate values (do not sort or remove them though)
     for( unsigned k=0; k<values.size(); k++)
     {
         if( column_indices[k] < 0 )
@@ -52,15 +53,15 @@ template<class real_type>
 }
 
 template<class real_type>
-cusp::csr_matrix<int, real_type, cusp::host_memory> window_stencil(
+dg::SparseMatrix<int, real_type, thrust::host_vector> window_stencil(
         unsigned stencil_size,
         const RealGrid1d<real_type>& local,
         const RealGrid1d<real_type>& global,
         dg::bc bcx)
 {
-    cusp::array1d<real_type, cusp::host_memory> values;
-    cusp::array1d<int, cusp::host_memory> row_offsets;
-    cusp::array1d<int, cusp::host_memory> column_indices;
+    thrust::host_vector<real_type> values;
+    thrust::host_vector<int> row_offsets;
+    thrust::host_vector<int> column_indices;
 
     unsigned num_rows = local.size();
     unsigned num_cols = global.size();
@@ -79,24 +80,20 @@ cusp::csr_matrix<int, real_type, cusp::host_memory> window_stencil(
     }
     set_boundary( values, column_indices, bcx, num_cols);
 
-    cusp::csr_matrix<int, real_type, cusp::host_memory> A(
-            num_rows, num_cols, values.size());
-    A.row_offsets = row_offsets;
-    A.column_indices = column_indices;
-    A.values = values;
-    return A;
+    // DO NOT SORT and KEEP DUPLICATES
+    return {num_rows, num_cols, row_offsets, column_indices, values};
 }
 
 // Rethink this approach if we ever need to make it work with MPI again
 template<class real_type>
-cusp::csr_matrix<int, real_type, cusp::host_memory> limiter_stencil(
+dg::SparseMatrix<int, real_type, thrust::host_vector> limiter_stencil(
         const RealGrid1d<real_type>& local,
         const RealGrid1d<real_type>& global,
         dg::bc bcx)
 {
-    cusp::array1d<real_type, cusp::host_memory> values;
-    cusp::array1d<int, cusp::host_memory> row_offsets;
-    cusp::array1d<int, cusp::host_memory> column_indices;
+    thrust::host_vector<real_type> values;
+    thrust::host_vector<int> row_offsets;
+    thrust::host_vector<int> column_indices;
 
     unsigned num_rows = local.size();
     unsigned num_cols = global.size();
@@ -112,9 +109,9 @@ cusp::csr_matrix<int, real_type, cusp::host_memory> limiter_stencil(
     row_offsets.push_back( 0);
     for( unsigned k=0; k<local.N(); k++)
     {
-        row_offsets.push_back(row_offsets[row_offsets.size()-1] + 3*local.n());
+        row_offsets.push_back(row_offsets.back() + 3*local.n());
         for( unsigned j=1; j<local.n(); j++)
-            row_offsets.push_back(row_offsets[row_offsets.size()-1]);
+            row_offsets.push_back(row_offsets.back());
         // Order is important
         for( unsigned j=0; j<local.n(); j++)
         {
@@ -135,28 +132,25 @@ cusp::csr_matrix<int, real_type, cusp::host_memory> limiter_stencil(
     assert( row_offsets.size() == num_rows+1);
     set_boundary( values, column_indices, bcx, num_cols);
 
-    cusp::csr_matrix<int, real_type, cusp::host_memory> A(
-            num_rows, num_cols, values.size());
-    A.row_offsets = row_offsets;
-    A.column_indices = column_indices;
-    A.values = values;
-    return A;
+    // DO NOT SORT and KEEP DUPLICATES
+    return {num_rows, num_cols, row_offsets, column_indices, values};
 }
 
 template<class real_type>
-cusp::csr_matrix< int, real_type, cusp::host_memory> identity_matrix( const RealGrid1d<real_type>& local, const RealGrid1d<real_type>& global)
+dg::SparseMatrix< int, real_type, thrust::host_vector> identity_matrix( const RealGrid1d<real_type>& local, const RealGrid1d<real_type>& global)
 {
-    cusp::csr_matrix<int,real_type,cusp::host_memory> A( local.size(),
-            global.size(), local.size());
     int L0 = round((local.x0() - global.x0())/global.h())*global.n();
-    A.row_offsets[0] = 0;
+    thrust::host_vector<real_type> values( local.size());
+    thrust::host_vector<int> row_offsets( local.size()+1);
+    thrust::host_vector<int> column_indices( local.size());
+    row_offsets[0] = 0;
     for( unsigned i=0; i<local.size(); i++)
     {
-        A.row_offsets[i+1] = 1 + A.row_offsets[i];
-        A.column_indices[i] = L0 + i;
-        A.values[i] = 1.;
+        row_offsets[i+1] = 1 + row_offsets[i];
+        column_indices[i] = L0 + i;
+        values[i] = 1.;
     }
-    return A;
+    return {local.size(), global.size(), row_offsets, column_indices, values};
 }
 
 } //namespace detail

--- a/inc/dg/topology/stencil.h
+++ b/inc/dg/topology/stencil.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cusp/coo_matrix.h>
 #include "xspacelib.h"
 #ifdef MPI_VERSION
 #include "mpi_projection.h" // for make_mpi_matrix function

--- a/inc/dg/topology/stencil_t.cpp
+++ b/inc/dg/topology/stencil_t.cpp
@@ -42,12 +42,12 @@ TEST_CASE( "Stencil")
         {
             auto stencil = dg::create::limiter_stencil( g1d, bc);
             INFO( "Test "<<dg::bc2str( bc)<<" boundary");
-            for( unsigned i=0; i<stencil.row_offsets.size(); i++)
-                INFO( stencil.row_offsets[i]<<" ");
-            for( unsigned i=0; i<stencil.column_indices.size(); i++)
-                INFO( stencil.column_indices[i]<<" ");
-            for( unsigned i=0; i<stencil.column_indices.size(); i++)
-                INFO( stencil.values[i]<<" ");
+            for( unsigned i=0; i<stencil.row_offsets().size(); i++)
+                INFO( stencil.row_offsets()[i]<<" ");
+            for( unsigned i=0; i<stencil.column_indices().size(); i++)
+                INFO( stencil.column_indices()[i]<<" ");
+            for( unsigned i=0; i<stencil.column_indices().size(); i++)
+                INFO( stencil.values()[i]<<" ");
         }
     }
     SECTION( "Test DIR boundary");

--- a/inc/dg/topology/stencil_t.cpp
+++ b/inc/dg/topology/stencil_t.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <cusp/print.h>
 #include "average.h"
 #include "stencil.h"
 #include "filter.h"

--- a/inc/dg/topology/xspacelib.h
+++ b/inc/dg/topology/xspacelib.h
@@ -32,47 +32,42 @@ namespace dg{
 * @param lhs The left hand side matrix (duplicate entries lead to duplicate entries in result)
 * @param rhs The right hand side matrix (duplicate entries lead to duplicate entries in result)
 *
-* @return newly allocated cusp matrix containing the tensor product
-* @note use \c cusp::add and \c cusp::multiply to add and multiply matrices.
+* @return newly allocated matrix containing the tensor product
 */
 template< class T>
-cusp::csr_matrix< int, T, cusp::host_memory> tensorproduct(
-        const cusp::csr_matrix< int, T, cusp::host_memory>& lhs,
-        const cusp::csr_matrix< int, T, cusp::host_memory>& rhs)
+dg::SparseMatrix< int, T, thrust::host_vector> tensorproduct(
+        const dg::SparseMatrix< int, T, thrust::host_vector>& lhs,
+        const dg::SparseMatrix< int, T, thrust::host_vector>& rhs)
 {
     //dimensions of the matrix
-    int num_rows     = lhs.num_rows*rhs.num_rows;
-    int num_cols     = lhs.num_cols*rhs.num_cols;
-    int num_entries  = lhs.num_entries* rhs.num_entries;
+    size_t num_rows     = lhs.num_rows()*rhs.num_rows();
+    size_t num_cols     = lhs.num_cols()*rhs.num_cols();
+    size_t num_entries  = lhs.num_entries()* rhs.num_entries();
     // allocate output matrix
-    cusp::array1d<int, cusp::host_memory> A_row_offsets(num_rows+1), A_column_indices( num_entries);
-    cusp::array1d<T, cusp::host_memory> A_values( num_entries);
+    thrust::host_vector<int> A_row_offsets(num_rows+1), A_column_indices( num_entries);
+    thrust::host_vector<T> A_values( num_entries);
     //LHS x RHS
     A_row_offsets[0] = 0;
     int counter = 0;
-    for( unsigned i=0; i<lhs.num_rows; i++)
-    for( unsigned j=0; j<rhs.num_rows; j++)
+    for( unsigned i=0; i<lhs.num_rows(); i++)
+    for( unsigned j=0; j<rhs.num_rows(); j++)
     {
         int num_entries_in_row =
-            (lhs.row_offsets[i+1] - lhs.row_offsets[i])*
-            (rhs.row_offsets[j+1] - rhs.row_offsets[j]);
-        A_row_offsets[i*rhs.num_rows+j+1] =
-            A_row_offsets[i*rhs.num_rows+j] + num_entries_in_row;
-        for( int k=lhs.row_offsets[i]; k<lhs.row_offsets[i+1]; k++)
-        for( int l=rhs.row_offsets[j]; l<rhs.row_offsets[j+1]; l++)
+            (lhs.row_offsets()[i+1] - lhs.row_offsets()[i])*
+            (rhs.row_offsets()[j+1] - rhs.row_offsets()[j]);
+        A_row_offsets[i*rhs.num_rows()+j+1] =
+            A_row_offsets[i*rhs.num_rows()+j] + num_entries_in_row;
+        for( int k=lhs.row_offsets()[i]; k<lhs.row_offsets()[i+1]; k++)
+        for( int l=rhs.row_offsets()[j]; l<rhs.row_offsets()[j+1]; l++)
         {
             A_column_indices[counter] =
-                lhs.column_indices[k]*rhs.num_cols +  rhs.column_indices[l];
-            A_values[counter]  = lhs.values[k]*rhs.values[l];
+                lhs.column_indices()[k]*rhs.num_cols() +  rhs.column_indices()[l];
+            A_values[counter]  = lhs.values()[k]*rhs.values()[l];
             counter++;
         }
     }
     // allocate output matrix
-    cusp::csr_matrix<int, T, cusp::host_memory> A(num_rows, num_cols, num_entries);
-    A.row_offsets = A_row_offsets;
-    A.column_indices = A_column_indices;
-    A.values = A_values;
-    return A;
+    return { num_rows, num_cols, A_row_offsets, A_column_indices, A_values};
 }
 
 /**
@@ -88,83 +83,50 @@ cusp::csr_matrix< int, T, cusp::host_memory> tensorproduct(
 * @param lhs The left hand side matrix (duplicate entries lead to duplicate entries in result)
 * @param rhs The right hand side matrix (duplicate entries lead to duplicate entries in result)
 *
-* @return newly allocated cusp matrix containing the tensor product
-* @note use \c cusp::add and \c cusp::multiply to add and multiply matrices.
+* @return newly allocated sparse matrix containing the tensor product
 */
 template< class T>
-cusp::csr_matrix< int, T, cusp::host_memory> tensorproduct_cols(
-        const cusp::csr_matrix< int, T, cusp::host_memory>& lhs,
-        const cusp::csr_matrix< int, T, cusp::host_memory>& rhs)
+dg::SparseMatrix< int, T, thrust::host_vector> tensorproduct_cols(
+        const dg::SparseMatrix< int, T, thrust::host_vector>& lhs,
+        const dg::SparseMatrix< int, T, thrust::host_vector>& rhs)
 {
-    if( lhs.num_rows != rhs.num_rows)
-        throw Error( Message(_ping_)<<"lhs and rhs must have same number of rows: "<<lhs.num_rows<<" rhs "<<rhs.num_rows);
+    if( lhs.num_rows() != rhs.num_rows())
+        throw Error( Message(_ping_)<<"lhs and rhs must have same number of rows: "<<lhs.num_rows()<<" rhs "<<rhs.num_rows());
 
     //dimensions of the matrix
-    int num_rows     = lhs.num_rows;
-    int num_cols     = lhs.num_cols*rhs.num_cols;
-    int num_entries = 0;
-    for( unsigned i=0; i<lhs.num_rows; i++)
+    size_t num_rows     = lhs.num_rows();
+    size_t num_cols     = lhs.num_cols()*rhs.num_cols();
+    size_t num_entries = 0;
+    for( unsigned i=0; i<lhs.num_rows(); i++)
     {
         int num_entries_in_row =
-            (lhs.row_offsets[i+1] - lhs.row_offsets[i])*
-            (rhs.row_offsets[i+1] - rhs.row_offsets[i]);
+            (lhs.row_offsets()[i+1] - lhs.row_offsets()[i])*
+            (rhs.row_offsets()[i+1] - rhs.row_offsets()[i]);
         num_entries += num_entries_in_row;
     }
     // allocate output matrix
-    cusp::array1d<int, cusp::host_memory> A_row_offsets(num_rows+1), A_column_indices( num_entries);
-    cusp::array1d<T, cusp::host_memory> A_values( num_entries);
+    thrust::host_vector<int> A_row_offsets(num_rows+1), A_column_indices( num_entries);
+    thrust::host_vector<T> A_values( num_entries);
     //LHS x RHS
     A_row_offsets[0] = 0;
     int counter = 0;
-    for( unsigned i=0; i<lhs.num_rows; i++)
+    for( unsigned i=0; i<lhs.num_rows(); i++)
     {
         int num_entries_in_row =
-            (lhs.row_offsets[i+1] - lhs.row_offsets[i])*
-            (rhs.row_offsets[i+1] - rhs.row_offsets[i]);
+            (lhs.row_offsets()[i+1] - lhs.row_offsets()[i])*
+            (rhs.row_offsets()[i+1] - rhs.row_offsets()[i]);
         A_row_offsets[i+1] = A_row_offsets[i] + num_entries_in_row;
-        for( int k=lhs.row_offsets[i]; k<lhs.row_offsets[i+1]; k++)
-        for( int l=rhs.row_offsets[i]; l<rhs.row_offsets[i+1]; l++)
+        for( int k=lhs.row_offsets()[i]; k<lhs.row_offsets()[i+1]; k++)
+        for( int l=rhs.row_offsets()[i]; l<rhs.row_offsets()[i+1]; l++)
         {
             A_column_indices[counter] =
-                lhs.column_indices[k]*rhs.num_cols +  rhs.column_indices[l];
-            A_values[counter]  = lhs.values[k]*rhs.values[l];
+                lhs.column_indices()[k]*rhs.num_cols() +  rhs.column_indices()[l];
+            A_values[counter]  = lhs.values()[k]*rhs.values()[l];
             counter++;
         }
     }
-    cusp::csr_matrix<int, T, cusp::host_memory> A(num_rows, num_cols, num_entries);
-    A.row_offsets = A_row_offsets;
-    A.column_indices = A_column_indices;
-    A.values = A_values;
-    return A;
+    return { num_rows, num_cols, A_row_offsets, A_column_indices, A_values};
 }
-///@cond
-//template< class T>
-//cusp::coo_matrix< int, T, cusp::host_memory> tensorproduct(
-//        const cusp::coo_matrix< int, T, cusp::host_memory>& lhs,
-//        const cusp::coo_matrix< int, T, cusp::host_memory>& rhs)
-//{
-//    //dimensions of the matrix
-//    int num_rows     = lhs.num_rows*rhs.num_rows;
-//    int num_cols     = lhs.num_cols*rhs.num_cols;
-//    int num_entries  = lhs.num_entries* rhs.num_entries;
-//    // allocate output matrix
-//    cusp::coo_matrix<int, T, cusp::host_memory> A(num_rows, num_cols, num_entries);
-//    //LHS x RHS
-//    int counter = 0;
-//    for( int k=0; k<lhs.num_entries; k++)
-//    for( int l=0; l<rhs.num_entries; l++)
-//    {
-//        A.row_indices[counter] =
-//            lhs.row_indices[k]*rhs.num_rows + rhs.row_indices[l];
-//        A.column_indices[counter] =
-//            lhs.column_indices[k]*rhs.num_cols +  rhs.column_indices[l];
-//        A.values[counter]  = lhs.values[k]*rhs.values[l];
-//        counter++;
-//    }
-//    return A;
-//}
-// tensorproduct_cols does not work for coo_matrix without converting to csr_matrix ...
-///@endcond
 
 
 namespace create{

--- a/inc/geometries/Makefile
+++ b/inc/geometries/Makefile
@@ -12,16 +12,16 @@ CPPFILES=$(wildcard *.cpp)
 all: $(CPPFILES:%.cpp=%)
 
 %_t: %_t.cpp
-	$(CC) $(OPT) $(CFLAGS) $< -o $@ $(INCLUDE) $(LIBS) $(JSONLIB) -g
+	$(CC) $(OPT) $(CFLAGS) $< -o $@ $(INCLUDE) $(LIBS) $(JSONLIB) -g $(SPARSELIB)
 
 %_b: %_b.cpp
-	$(CC) $(OPT) $(CFLAGS) $< -o $@ $(INCLUDE) $(LIBS) $(JSONLIB) -g
+	$(CC) $(OPT) $(CFLAGS) $< -o $@ $(INCLUDE) $(LIBS) $(JSONLIB) -g $(SPARSELIB)
 
 %_mpit: %_t.cpp
-	$(MPICC) $(OPT) $(INCLUDE) $(MPICFLAGS)  $< -o $@ $(LIBS) $(JSONLIB) -g -DWITH_MPI
+	$(MPICC) $(OPT) $(INCLUDE) $(MPICFLAGS)  $< -o $@ $(LIBS) $(JSONLIB) -g -DWITH_MPI $(SPARSELIB)
 
 %_mpib: %_b.cpp
-	$(MPICC) $(OPT) $(MPICFLAGS) $< -o $@ -g $(INCLUDE) $(LIBS) $(JSONLIB) -g -DWITH_MPI
+	$(MPICC) $(OPT) $(MPICFLAGS) $< -o $@ -g $(INCLUDE) $(LIBS) $(JSONLIB) -g -DWITH_MPI $(SPARSELIB)
 
 
 

--- a/inc/geometries/Makefile
+++ b/inc/geometries/Makefile
@@ -12,16 +12,16 @@ CPPFILES=$(wildcard *.cpp)
 all: $(CPPFILES:%.cpp=%)
 
 %_t: %_t.cpp
-	$(CC) $(OPT) $(CFLAGS) $< -o $@ $(INCLUDE) $(LIBS) $(JSONLIB) -g $(SPARSELIB)
+	$(CC) $(OPT) $(CFLAGS) $< -o $@ $(INCLUDE) $(LIBS) $(JSONLIB) -g
 
 %_b: %_b.cpp
-	$(CC) $(OPT) $(CFLAGS) $< -o $@ $(INCLUDE) $(LIBS) $(JSONLIB) -g $(SPARSELIB)
+	$(CC) $(OPT) $(CFLAGS) $< -o $@ $(INCLUDE) $(LIBS) $(JSONLIB) -g
 
 %_mpit: %_t.cpp
-	$(MPICC) $(OPT) $(INCLUDE) $(MPICFLAGS)  $< -o $@ $(LIBS) $(JSONLIB) -g -DWITH_MPI $(SPARSELIB)
+	$(MPICC) $(OPT) $(INCLUDE) $(MPICFLAGS)  $< -o $@ $(LIBS) $(JSONLIB) -g -DWITH_MPI
 
 %_mpib: %_b.cpp
-	$(MPICC) $(OPT) $(MPICFLAGS) $< -o $@ -g $(INCLUDE) $(LIBS) $(JSONLIB) -g -DWITH_MPI $(SPARSELIB)
+	$(MPICC) $(OPT) $(MPICFLAGS) $< -o $@ -g $(INCLUDE) $(LIBS) $(JSONLIB) -g -DWITH_MPI
 
 
 

--- a/inc/geometries/ds_curv_t.cpp
+++ b/inc/geometries/ds_curv_t.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <iomanip>
 
 #ifdef WITH_MPI
 #include <mpi.h>

--- a/inc/geometries/fieldaligned.h
+++ b/inc/geometries/fieldaligned.h
@@ -1,8 +1,6 @@
 #pragma once
 #include <cmath>
 #include <array>
-#include <cusp/csr_matrix.h>
-#include <cusp/transpose.h>
 
 #include "dg/algorithm.h"
 #include "magnetic_field.h"
@@ -535,8 +533,13 @@ struct Fieldaligned
     bool m_have_adjoint = false;
     void updateAdjoint( )
     {
-        cusp::transpose( m_plus, m_plusT);
-        cusp::transpose( m_minus, m_minusT);
+        // Transpose only works on host
+        dg::SparseMatrix< typename IMatrix::index_type, typename IMatrix::value_type, thrust::host_vector>
+            tmp;
+        tmp = m_plus;
+        m_plusT = tmp.transpose();
+        tmp = m_minus;
+        m_minusT = tmp.transpose();
         m_have_adjoint = true;
     }
 };
@@ -633,9 +636,8 @@ Fieldaligned<Geometry, IMatrix, container>::Fieldaligned(
         projection = dg::create::projection( *grid_transform, grid_fine);
     else
     {
-        multi = dg::create::projection( grid_equidist, grid_fine, project_m);
-        fine = dg::create::inv_backproject( *grid_transform);
-        cusp::multiply( fine, multi, projection);
+        projection = dg::create::inv_backproject( *grid_transform)*
+            dg::create::projection( grid_equidist, grid_fine, project_m);
     }
     std::array<dg::HVec*,3> xcomp{ &yp[0], &Xf, &ym[0]};
     std::array<dg::HVec*,3> ycomp{ &yp[1], &Yf, &ym[1]};
@@ -645,19 +647,14 @@ Fieldaligned<Geometry, IMatrix, container>::Fieldaligned(
     {
         if( inter_m == "dg")
         {
-            fine = dg::create::interpolation( *xcomp[u], *ycomp[u],
+            *result[u] = projection*dg::create::interpolation( *xcomp[u], *ycomp[u],
                 *grid_transform, bcx, bcy, "dg");
-            cusp::multiply( projection, fine, multi);
-            dg::blas2::transfer( multi, *result[u]);
         }
         else
         {
-            fine = dg::create::backproject( *grid_transform); // from dg to equidist
-            multi = dg::create::interpolation( *xcomp[u], *ycomp[u],
-                grid_equidist, bcx, bcy, inter_m);
-            cusp::multiply( multi, fine, temp);
-            cusp::multiply( projection, temp, multi);
-            dg::blas2::transfer( multi, *result[u]);
+            *result[u] = projection *  dg::create::interpolation( *xcomp[u], *ycomp[u],
+                grid_equidist, bcx, bcy, inter_m) *  dg::create::backproject(
+                *grid_transform); // from dg to equidist
         }
     }
     }

--- a/inc/geometries/fieldaligned.h
+++ b/inc/geometries/fieldaligned.h
@@ -533,13 +533,8 @@ struct Fieldaligned
     bool m_have_adjoint = false;
     void updateAdjoint( )
     {
-        // Transpose only works on host
-        dg::SparseMatrix< typename IMatrix::index_type, typename IMatrix::value_type, thrust::host_vector>
-            tmp;
-        tmp = m_plus;
-        m_plusT = tmp.transpose();
-        tmp = m_minus;
-        m_minusT = tmp.transpose();
+        m_plusT = m_plus.transpose();
+        m_minusT = m_minus.transpose();
         m_have_adjoint = true;
     }
 };

--- a/inc/matrix/invtridiag_t.cu
+++ b/inc/matrix/invtridiag_t.cu
@@ -4,14 +4,8 @@
 #include "dg/algorithm.h"
 #include "tridiaginv.h"
 
-#include <cusp/transpose.h>
-#include <cusp/print.h>
-#include <cusp/array2d.h>
-#include <cusp/elementwise.h>
-#include <cusp/blas/blas.h>
-using memory_type = cusp::host_memory;
-using CooMatrix =  cusp::coo_matrix<int, double, memory_type>;
-using DiaMatrix =  cusp::dia_matrix<int, double, memory_type>;
+using CooMatrix =  dg::SquareMatrix<double>;
+using DiaMatrix =  dg::TriDiagonal<thrust::host_vector<double>>;
 using Container = dg::HVec;
 int main()
 {
@@ -21,39 +15,36 @@ int main()
     std::vector<double> c = {0., -1.98242,     -4.44712,   -5.26401,   -7.42602, -7.09812};
     unsigned size = a.size();
 
-    DiaMatrix T;
-    CooMatrix Tinv, Tinv_sol, Tinv_error;
-    cusp::array2d<double ,memory_type> H(size,size), error(size,size,0.);
+    dg::TriDiagonal<thrust::host_vector<double>> T(size);
+    dg::SquareMatrix<double> Tinv, Tinv_sol, Tinv_error( size, 0.);
+    dg::SquareMatrix<double> H(size);
     H(0,0) = 0.505249;  H(0,1) = 0.000814795;  H(0,2) =  8.4358e-6;     H(0,3) = 6.26392e-8;     H(0,4) =  1.51587e-10;
     H(1,0) = 0.227217;  H(1,1) = 0.227217;     H(1,2) =  0.00235244;    H(1,3) = 0.0000174678;   H(1,4) =  4.22721e-8;
     H(2,0) = 0.19139;   H(2,1) = 0.19139;      H(2,2) =  0.19139;       H(2,3) = 0.00142115;     H(2,4) =  3.43918e-6;
     H(3,0) = 0.134988;  H(3,1) = 0.134988;     H(3,2) =  0.134988;      H(3,3) = 0.134988;       H(3,4) =  0.000326671;
     H(4,0) = 0.140882;  H(4,1) = 0.140882;     H(4,2) =  0.140882;      H(4,3) = 0.140882;       H(4,4) = 0.140882;
-    cusp::convert(H,Tinv_sol);
-    cusp::convert(error,Tinv_error);
+    Tinv_sol = H;
 
-    T.resize(size, size, 3*size-2, 3);
-    T.diagonal_offsets[0] = -1;
-    T.diagonal_offsets[1] =  0;
-    T.diagonal_offsets[2] =  1;
     for( unsigned i=0; i<size-1; i++)
     {
-        T.values(i,1)   =  a[i];  // 0 diagonal
-        T.values(i,0)   =  c[i];  // -1 diagonal
-        T.values(i,2)   =  b[i];  // +1 diagonal //dia_rows entry works since its outside of matrix
+        T.O[i]   =  a[i];  // 0 diagonal
+        T.M[i]   =  c[i];  // -1 diagonal
+        T.P[i]   =  b[i];  // +1 diagonal //dia_rows entry works since its outside of matrix
     }
-    T.values(size-1,1) =  a[size-1];
-    T.values(size-1,0) =  c[size-1];
+    T.O[size-1] =  a[size-1];
+    T.M[size-1] =  c[size-1];
     std::cout << "T matrix\n";
-    cusp::print(T);
+    for( unsigned u=0; u<size; u++)
+        std::cout << T.M[u]<<" "<<T.O[u]<<" "<<T.P[u]<<"\n";
+    std::cout << std::endl;
 
-    dg::mat::TridiagInvDF<Container, DiaMatrix, CooMatrix> invtridiag(a);
+    dg::mat::TridiagInvDF<double> invtridiag(a);
     t.tic();
     invtridiag(a,b,c, Tinv);
     t.toc();
     std::cout << "Difference between Tinv and solution\n";
-    cusp::subtract(Tinv_sol, Tinv, Tinv_error);
-    cusp::print(Tinv_error);
+    Tinv_error = Tinv_sol - Tinv;
+    std::cout << Tinv_error;
     std::cout <<  "time: "<< t.diff()<<"s \n";
 
     t.tic();
@@ -61,8 +52,8 @@ int main()
     t.toc();
 
     std::cout << "Difference between Tinv and solution\n";
-    cusp::subtract(Tinv_sol, Tinv, Tinv_error);
-    cusp::print(Tinv_error);
+    Tinv_error = Tinv_sol - Tinv;
+    std::cout << Tinv_error;
     std::cout <<  "time: "<< t.diff()<<"s \n";
     return 0;
 }

--- a/inc/matrix/polarization_init_t.cu
+++ b/inc/matrix/polarization_init_t.cu
@@ -30,8 +30,6 @@ private:
 };
 
 
-using DiaMatrix = cusp::dia_matrix<int, double, cusp::device_memory>;
-using CooMatrix = cusp::coo_matrix<int, double, cusp::device_memory>;
 using Matrix = dg::DMatrix;
 using Container = dg::DVec;
 using SubContainer = dg::DVec;

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -10,6 +10,7 @@ do
     do
         echo "#########################"
         echo "DIRECTORY" $dir "TEST DEVICE" $dev
+        make clean # Delete leftovers from previous tests
         make tests -j 4 device=$dev
         ./tests
         make mpi-tests -j 4 device=$dev


### PR DESCRIPTION
This update removes our dependency on the no longer maintained cusp library. The main reason is to be able to update the thrust library and enable the use of its CMakeFile system. In order to do so we have:
 - Novel `dg::SparseMatrix` class
 - Incraeasd usage of `dg::TriDiagonal` and `dg::SquareMatrix`
 - Dispatch to cusparse for gpu matrix-vector products
 - Update default build dependencies